### PR TITLE
docs: remove manual test-examples.yml edit requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -472,7 +472,6 @@ Use this checklist when creating a new provider skill:
 - [ ] Update `README.md` - Add skill to Provider Skills table
 - [ ] Update `providers.yaml` - Add provider entry with documentation URLs
 - [ ] Update `scripts/test-agent-scenario.sh` - Add test scenarios for the new provider
-- [ ] Update `.github/workflows/test-examples.yml` - Add provider to all three test matrices (express, nextjs, fastapi)
 - [ ] Run example tests: `cd examples/express && npm test`
 - [ ] Run validation: `./scripts/validate-provider.sh {provider}-webhooks`
 - [ ] Run agent test: `./scripts/test-agent-scenario.sh {provider}-express --dry-run`
@@ -541,7 +540,6 @@ Gather this information:
 7. Update integration files:
    - `README.md` - Add skill to Provider Skills table
    - `scripts/test-agent-scenario.sh` - Add test scenarios
-   - `.github/workflows/test-examples.yml` - Add provider to test matrices
 8. Test with agent: `./scripts/test-agent-scenario.sh {provider}-express --dry-run`
 
 ## Skill Discoverability
@@ -763,7 +761,6 @@ The automated review checks skill content and tests, but does **not** verify int
 1. **README.md** — Provider added to Provider Skills table
 2. **providers.yaml** — Provider entry added with documentation URLs
 3. **scripts/test-agent-scenario.sh** — At least one scenario added (e.g. `{provider}-express`) in both `usage()` and `get_scenario_config()`
-4. **.github/workflows/test-examples.yml** — Provider added to all three test matrices (express, nextjs, fastapi)
 
 ### Step 3: Spot-Check Skill Content
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,8 +121,7 @@ All providers and their official documentation URLs are tracked in `providers.ya
 1. Add the provider entry to `providers.yaml` with documentation URLs
 2. Generate the skill using the config: `./scripts/generate-skills.sh generate {provider} --config providers.yaml`
 3. Update the README.md Provider Skills table
-4. Add the provider to `.github/workflows/test-examples.yml` matrices
-5. Add at least one scenario to `scripts/test-agent-scenario.sh`
+4. Add at least one scenario to `scripts/test-agent-scenario.sh`
 
 **Validate locally before pushing:**
 
@@ -318,7 +317,7 @@ Use these conventions so PRs are consistent and easy to review.
 
 1. **Summary** — One or two sentences: what this PR does (e.g. "Add webhook skill for Deepgram" or "Improvements to deepgram-webhooks skill").
 2. **What's included** — For new or large PRs: SKILL.md, references (overview, setup, verification), examples (Express, Next.js, FastAPI) with test frameworks.
-3. **Integration** — If applicable: README (Provider Skills table), `scripts/test-agent-scenario.sh` (scenario added), `.github/workflows/test-examples.yml` (provider in matrices).
+3. **Integration** — If applicable: README (Provider Skills table), `scripts/test-agent-scenario.sh` (scenario added).
 4. **Testing** — How to run tests, e.g.:
    - `cd skills/{provider}-webhooks/examples/express && npm test`
    - `cd skills/{provider}-webhooks/examples/nextjs && npm test`

--- a/providers.yaml
+++ b/providers.yaml
@@ -14,8 +14,7 @@
 #   1. Add provider entry here with documentation URLs
 #   2. Generate or create the skill
 #   3. Update README.md Provider Skills table
-#   4. Add to .github/workflows/test-examples.yml matrices
-#   5. Add scenario to scripts/test-agent-scenario.sh
+#   4. Add scenario to scripts/test-agent-scenario.sh
 
 providers:
   - name: chargebee

--- a/scripts/validate-provider.sh
+++ b/scripts/validate-provider.sh
@@ -221,11 +221,6 @@ validate_integration() {
     errors+=("providers.yaml not found at repository root")
   fi
   
-  # Check test-examples.yml has provider in matrices
-  if ! grep -q "$provider" "$ROOT_DIR/.github/workflows/test-examples.yml"; then
-    errors+=("$provider not found in .github/workflows/test-examples.yml matrices")
-  fi
-  
   # Check test-agent-scenario.sh has at least one scenario
   if ! grep -q "$provider_name" "$ROOT_DIR/scripts/test-agent-scenario.sh"; then
     errors+=("No scenario for $provider_name in scripts/test-agent-scenario.sh")
@@ -330,8 +325,7 @@ if [ ${#FAILED_PROVIDERS[@]} -gt 0 ]; then
   log "  1. All required skill files (SKILL.md, references/, examples/)"
   log "  2. README.md - Add provider to Provider Skills table"
   log "  3. providers.yaml - Add provider entry with documentation URLs"
-  log "  4. .github/workflows/test-examples.yml - Add provider to all matrices"
-  log "  5. scripts/test-agent-scenario.sh - Add at least one test scenario"
+  log "  4. scripts/test-agent-scenario.sh - Add at least one test scenario"
   exit 1
 else
   log "${GREEN}All ${#PASSED_PROVIDERS[@]} provider(s) passed validation!${NC}"


### PR DESCRIPTION
## Summary

Remove outdated documentation that instructed contributors to manually edit `.github/workflows/test-examples.yml` when adding new provider skills.

The CI workflow now uses **dynamic matrix detection** to automatically discover and test changed provider skills — no manual workflow edits needed.

## Changes

| File | Update |
|------|--------|
| `AGENTS.md` | Removed from 3 checklists/process steps |
| `CONTRIBUTING.md` | Removed from provider workflow and PR description template |
| `providers.yaml` | Removed from header comments |
| `scripts/validate-provider.sh` | Removed the grep check and error message |

## How Dynamic Detection Works

- **On PRs**: Only skills with changes in `skills/{provider}/` are tested
- **On push to main**: All skills are tested

This was implemented in the `detect-changes` job in `test-examples.yml`.

## Test Plan

- [x] `./scripts/validate-provider.sh stripe-webhooks` passes
- [ ] CI passes on this PR

Made with [Cursor](https://cursor.com)