### PR TITLE
feat: dynamic agent test scenarios from providers.yaml

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -470,11 +470,10 @@ Use this checklist when creating a new provider skill:
 
 #### Integration
 - [ ] Update `README.md` - Add skill to Provider Skills table
-- [ ] Update `providers.yaml` - Add provider entry with documentation URLs
-- [ ] Update `scripts/test-agent-scenario.sh` - Add test scenarios for the new provider
+- [ ] Update `providers.yaml` - Add provider entry with documentation URLs and `testScenario`
 - [ ] Run example tests: `cd examples/express && npm test`
 - [ ] Run validation: `./scripts/validate-provider.sh {provider}-webhooks`
-- [ ] Run agent test: `./scripts/test-agent-scenario.sh {provider}-express --dry-run`
+- [ ] Run agent test: `./scripts/test-agent-scenario.sh {provider} express --dry-run`
 
 ### Provider Research (Do This First)
 
@@ -539,8 +538,8 @@ Gather this information:
 6. Run example tests locally: `cd examples/express && npm test` (repeat for each framework)
 7. Update integration files:
    - `README.md` - Add skill to Provider Skills table
-   - `scripts/test-agent-scenario.sh` - Add test scenarios
-8. Test with agent: `./scripts/test-agent-scenario.sh {provider}-express --dry-run`
+   - `providers.yaml` - Add provider entry with `testScenario` field
+8. Test with agent: `./scripts/test-agent-scenario.sh {provider} express --dry-run`
 
 ## Skill Discoverability
 
@@ -712,28 +711,38 @@ cd skills/{provider}-webhooks/examples/express && npm test
 **Run agent integration test:**
 ```bash
 # Dry run (shows what would happen)
-./scripts/test-agent-scenario.sh {provider}-express --dry-run
+./scripts/test-agent-scenario.sh {provider} express --dry-run
 
 # Full test (requires Claude CLI)
-./scripts/test-agent-scenario.sh {provider}-express
+./scripts/test-agent-scenario.sh {provider} express
+
+# List available providers
+./scripts/test-agent-scenario.sh --help
 ```
 
 ### Adding Test Scenarios
 
-When adding a new provider skill, add scenarios to `scripts/test-agent-scenario.sh`:
+When adding a new provider skill, add `testScenario` to the provider entry in `providers.yaml`:
 
-```bash
-# In the usage() function, add:
-echo "  {provider}-express   - {Provider} webhook handling in Express"
-
-# In get_scenario_config(), add:
-{provider}-express)
-    PROVIDER="{provider}"
-    FRAMEWORK="express"
-    SKILL_NAME="{provider}-webhooks"
-    PROMPT="Add {Provider} webhook handling to my Express app. I want to handle {common_event} events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-    ;;
+```yaml
+providers:
+  - name: {provider}
+    displayName: {Provider}
+    docs:
+      webhooks: https://...
+    notes: >
+      ...
+    testScenario:
+      events:
+        - event.type.one
+        - event.type.two
+      # Optional: custom prompt (uses default template if not specified)
+      # prompt: "Custom prompt with {Provider}, {framework}, {events} placeholders"
+      # Optional: override skill name (default is {name}-webhooks)
+      # skillName: custom-skill-name
 ```
+
+The test script reads scenarios from `providers.yaml` dynamically - no script modifications needed.
 
 ## Reviewing a Provider Skill or PR
 
@@ -759,8 +768,7 @@ This runs all example tests and uses Claude to review the skill against provider
 The automated review checks skill content and tests, but does **not** verify integration with repository infrastructure. Manually confirm:
 
 1. **README.md** — Provider added to Provider Skills table
-2. **providers.yaml** — Provider entry added with documentation URLs
-3. **scripts/test-agent-scenario.sh** — At least one scenario added (e.g. `{provider}-express`) in both `usage()` and `get_scenario_config()`
+2. **providers.yaml** — Provider entry added with documentation URLs and `testScenario` field
 
 ### Step 3: Spot-Check Skill Content
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -321,6 +321,55 @@ For skills to be considered effective:
 
 ---
 
+## Running Agent Tests with Scripts
+
+The repository includes a script to automate agent test scenarios:
+
+```bash
+# List available providers and frameworks
+./scripts/test-agent-scenario.sh --help
+
+# Run a test scenario (dry-run to see what would happen)
+./scripts/test-agent-scenario.sh stripe express --dry-run
+
+# Run actual test (requires Claude CLI)
+./scripts/test-agent-scenario.sh stripe express
+
+# Test with other providers/frameworks
+./scripts/test-agent-scenario.sh shopify nextjs
+./scripts/test-agent-scenario.sh github fastapi
+./scripts/test-agent-scenario.sh hookdeck-event-gateway express
+```
+
+### How It Works
+
+1. Creates a fresh project directory in `/tmp/webhook-skills-agent-test/`
+2. Initializes the project based on framework (Express, Next.js, or FastAPI)
+3. Installs the relevant skill via `npx skills add`
+4. Runs Claude CLI with a context-aware prompt
+5. Saves results to `test-results/` for manual evaluation
+
+### Configuration
+
+Test prompts and events are configured in `providers.yaml` at the repository root:
+
+```yaml
+providers:
+  - name: stripe
+    displayName: Stripe
+    # ... docs, notes ...
+    testScenario:
+      events:
+        - payment_intent.succeeded
+        - checkout.session.completed
+      # Optional custom prompt (uses default if not specified)
+      # prompt: "Custom prompt with {Provider}, {framework}, {events} placeholders"
+```
+
+To add a new test scenario, add the `testScenario` field to the provider in `providers.yaml`.
+
+---
+
 ## Automating Agent Tests (Future)
 
 ### Architecture

--- a/providers.yaml
+++ b/providers.yaml
@@ -1,7 +1,7 @@
 # Webhook Providers - Source of Truth
 #
 # This file is the authoritative list of all webhook providers supported by this repository.
-# Used for: skill generation, periodic reviews, CI validation, documentation reference.
+# Used for: skill generation, periodic reviews, CI validation, agent testing, documentation.
 #
 # Usage:
 #   # Review all providers against their official docs
@@ -10,11 +10,26 @@
 #   # Generate a specific provider from this config
 #   ./scripts/generate-skills.sh generate stripe --config providers.yaml
 #
+#   # Run agent test scenario
+#   ./scripts/test-agent-scenario.sh stripe express
+#
+#   # List available providers for testing
+#   ./scripts/generate-skills.sh list-providers --config providers.yaml
+#
+# Provider fields:
+#   name          - kebab-case name (e.g., "stripe", "hookdeck-event-gateway")
+#   displayName   - Human-readable name (e.g., "Stripe", "Hookdeck Event Gateway")
+#   docs          - Documentation URLs (webhooks, verification, events, api)
+#   notes         - Context for AI agents during skill generation
+#   testScenario  - Configuration for agent testing (optional):
+#     events      - Array of event types to test with
+#     prompt      - Custom prompt template (uses default if not specified)
+#     skillName   - Override skill directory name (default: {name}-webhooks)
+#
 # When adding a new provider skill:
-#   1. Add provider entry here with documentation URLs
+#   1. Add provider entry here with documentation URLs and testScenario
 #   2. Generate or create the skill
 #   3. Update README.md Provider Skills table
-#   4. Add scenario to scripts/test-agent-scenario.sh
 
 providers:
   - name: chargebee
@@ -25,6 +40,10 @@ providers:
     notes: >
       Subscription billing platform. Uses Basic Auth for webhook verification (not HMAC).
       Username and password are configured in Chargebee webhook settings.
+    testScenario:
+      events:
+        - subscription_created
+        - payment_succeeded
 
   - name: clerk
     displayName: Clerk
@@ -35,6 +54,10 @@ providers:
       User management platform. Uses Standard Webhooks (Svix) format with headers:
       webhook-id, webhook-timestamp, webhook-signature. Secret format is whsec_<base64>.
       HMAC-SHA256 with base64 encoding.
+    testScenario:
+      events:
+        - user.created
+        - session.created
 
   - name: deepgram
     displayName: Deepgram
@@ -44,6 +67,14 @@ providers:
       Speech-to-text transcription platform. Uses callback URLs with optional
       Basic Auth or token-based verification via dg-token header.
       Not traditional webhooks - these are transcription completion callbacks.
+    testScenario:
+      events:
+        - transcription callback
+      prompt: >
+        Add Deepgram webhook handling to my {framework} app. I want to receive 
+        transcription callbacks and verify the dg-token header. If you use any 
+        skills to help with this, add a comment in the code noting which skill(s) 
+        you referenced.
 
   - name: elevenlabs
     displayName: ElevenLabs
@@ -53,6 +84,10 @@ providers:
       Voice AI platform. Uses Standard Webhooks (Svix) format with headers:
       webhook-id, webhook-timestamp, webhook-signature. Secret format is whsec_<base64>.
       HMAC-SHA256 with base64 encoding.
+    testScenario:
+      events:
+        - voice.generation.completed
+        - voice.clone.completed
 
   - name: fusionauth
     displayName: FusionAuth
@@ -64,6 +99,10 @@ providers:
       Identity and access management platform. Uses JWT-based signature verification.
       Signatures are RSA-signed JWTs in the X-FusionAuth-Signature header.
       Verify using FusionAuth's public key from /.well-known/jwks.json endpoint.
+    testScenario:
+      events:
+        - user.create
+        - user.login.success
 
   - name: github
     displayName: GitHub
@@ -75,6 +114,10 @@ providers:
       Code hosting platform. Uses X-Hub-Signature-256 header with HMAC-SHA256 (hex encoded).
       Signature format is sha256=<hex_digest>. Always use timing-safe comparison.
       Common events: push, pull_request, issues, release.
+    testScenario:
+      events:
+        - push
+        - pull_request
 
   - name: openai
     displayName: OpenAI
@@ -85,6 +128,10 @@ providers:
       AI platform webhooks for fine-tuning jobs, batch completions, and async events.
       Uses Standard Webhooks (Svix) format with headers: webhook-id, webhook-timestamp,
       webhook-signature. Secret format is whsec_<base64>. HMAC-SHA256 with base64 encoding.
+    testScenario:
+      events:
+        - fine_tuning.job.succeeded
+        - batch.completed
 
   - name: paddle
     displayName: Paddle
@@ -96,6 +143,10 @@ providers:
       Payment and subscription platform. Uses Paddle-Signature header with HMAC-SHA256.
       Signature format includes timestamp (ts) and hash (h1). Secret starts with pdl_ntfset_.
       Official SDKs available: @paddle/paddle-node-sdk, paddle-billing (Python).
+    testScenario:
+      events:
+        - subscription.created
+        - transaction.completed
 
   - name: resend
     displayName: Resend
@@ -105,6 +156,10 @@ providers:
       Email API platform. Uses Standard Webhooks (Svix) format with headers:
       webhook-id, webhook-timestamp, webhook-signature. Secret format is whsec_<base64>.
       HMAC-SHA256 with base64 encoding. Events: email.sent, email.delivered, email.bounced.
+    testScenario:
+      events:
+        - email.delivered
+        - email.bounced
 
   - name: sendgrid
     displayName: SendGrid
@@ -115,6 +170,10 @@ providers:
       Email delivery platform. Uses ECDSA signatures with public key verification.
       Signature in X-Twilio-Email-Event-Webhook-Signature header. Timestamp in
       X-Twilio-Email-Event-Webhook-Timestamp header. Verify using SendGrid's public key.
+    testScenario:
+      events:
+        - delivered
+        - bounce
 
   - name: shopify
     displayName: Shopify
@@ -126,6 +185,10 @@ providers:
       E-commerce platform. Uses X-Shopify-Hmac-SHA256 header with HMAC-SHA256 (base64 encoded).
       Secret is the API secret key from Shopify Partners dashboard.
       Common events: orders/create, orders/paid, products/update.
+    testScenario:
+      events:
+        - orders/create
+        - orders/paid
 
   - name: stripe
     displayName: Stripe
@@ -138,3 +201,28 @@ providers:
       Signature format includes timestamp (t) and signature (v1). Secret starts with whsec_.
       Always use raw request body for verification. Common events: checkout.session.completed,
       payment_intent.succeeded, customer.subscription.created.
+    testScenario:
+      events:
+        - payment_intent.succeeded
+        - checkout.session.completed
+
+  - name: hookdeck-event-gateway
+    displayName: Hookdeck Event Gateway
+    docs:
+      webhooks: https://hookdeck.com/docs/verification
+      setup: https://hookdeck.com/docs/receive-webhooks
+    notes: >
+      Webhook infrastructure platform. Hookdeck Event Gateway receives webhooks from 
+      providers and forwards them to your app with an x-hookdeck-signature header.
+      Uses HMAC-SHA256 with base64 encoding. Signed content format is the raw request body.
+    testScenario:
+      skillName: hookdeck-event-gateway
+      events:
+        - webhooks via Event Gateway
+      prompt: >
+        Create a {framework} webhook handler that receives webhooks forwarded through 
+        Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from 
+        providers and forwards them to my app, adding an x-hookdeck-signature header for 
+        verification. I need to verify this signature using HMAC SHA-256 with base64 
+        encoding. If you use any skills to help with this, add a comment in the code 
+        noting which skill(s) you referenced.

--- a/scripts/skill-generator/lib/config.ts
+++ b/scripts/skill-generator/lib/config.ts
@@ -5,7 +5,7 @@
 import { readFileSync, existsSync } from 'fs';
 import { join, isAbsolute } from 'path';
 import { parse as parseYaml } from 'yaml';
-import type { ProviderConfig } from './types';
+import type { ProviderConfig, TestScenario } from './types';
 
 // Root directory of the repository (two levels up from lib/)
 const ROOT_DIR = join(__dirname, '..', '..', '..');
@@ -136,6 +136,7 @@ export function loadConfigFile(filePath: string): Map<string, ProviderConfig> {
         displayName: (config.displayName as string) || toDisplayName(name),
         docs: config.docs as ProviderConfig['docs'],
         notes: config.notes as string | undefined,
+        testScenario: config.testScenario as TestScenario | undefined,
       });
     }
   } else {
@@ -153,6 +154,7 @@ export function loadConfigFile(filePath: string): Map<string, ProviderConfig> {
         displayName: (config.displayName as string) || toDisplayName(key),
         docs: config.docs as ProviderConfig['docs'],
         notes: config.notes as string | undefined,
+        testScenario: config.testScenario as TestScenario | undefined,
       });
     }
   }

--- a/scripts/skill-generator/lib/scenario.ts
+++ b/scripts/skill-generator/lib/scenario.ts
@@ -1,0 +1,127 @@
+/**
+ * Scenario configuration for agent testing
+ * Used by test-agent-scenario.sh to get dynamic provider/framework config
+ */
+
+import { loadConfigFile, normalizeProviderName, toDisplayName } from './config';
+import type { ProviderConfig, ScenarioConfig, TestScenario } from './types';
+
+// Supported frameworks
+export const SUPPORTED_FRAMEWORKS = ['express', 'nextjs', 'fastapi'] as const;
+export type Framework = typeof SUPPORTED_FRAMEWORKS[number];
+
+/**
+ * Default prompt template used when provider doesn't specify a custom prompt
+ * Placeholders: {Provider}, {framework}, {events}
+ */
+const DEFAULT_PROMPT_TEMPLATE = `Add {Provider} webhook handling to my {framework} app. I want to handle {events} events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced.`;
+
+/**
+ * Get the skill name for a provider
+ * Uses testScenario.skillName if specified, otherwise defaults to {name}-webhooks
+ */
+export function getSkillName(provider: ProviderConfig): string {
+  if (provider.testScenario?.skillName) {
+    return provider.testScenario.skillName;
+  }
+  return `${provider.name}-webhooks`;
+}
+
+/**
+ * Build the prompt for a provider and framework
+ */
+export function buildPrompt(
+  provider: ProviderConfig,
+  framework: Framework
+): string {
+  const testScenario = provider.testScenario;
+  
+  // Use custom prompt if specified
+  const template = testScenario?.prompt || DEFAULT_PROMPT_TEMPLATE;
+  
+  // Format events list
+  const events = testScenario?.events?.join(' and ') || 'webhook';
+  
+  // Get display name
+  const displayName = provider.displayName || toDisplayName(provider.name);
+  
+  // Replace placeholders and trim whitespace (YAML > blocks add trailing newlines)
+  return template
+    .trim()
+    .replace(/\{Provider\}/g, displayName)
+    .replace(/\{provider\}/g, provider.name)
+    .replace(/\{framework\}/g, framework)
+    .replace(/\{events\}/g, events);
+}
+
+/**
+ * Get scenario configuration for a provider and framework
+ * Returns null if provider not found or framework invalid
+ */
+export function getScenarioConfig(
+  providerName: string,
+  framework: string,
+  configFile: string
+): ScenarioConfig | null {
+  // Validate framework
+  if (!SUPPORTED_FRAMEWORKS.includes(framework as Framework)) {
+    console.error(`Invalid framework: ${framework}`);
+    console.error(`Supported frameworks: ${SUPPORTED_FRAMEWORKS.join(', ')}`);
+    return null;
+  }
+  
+  // Load providers from config
+  const providers = loadConfigFile(configFile);
+  const normalizedName = normalizeProviderName(providerName);
+  const provider = providers.get(normalizedName);
+  
+  if (!provider) {
+    console.error(`Provider not found: ${providerName}`);
+    console.error(`Available providers: ${Array.from(providers.keys()).join(', ')}`);
+    return null;
+  }
+  
+  // Check if provider has testScenario configured
+  if (!provider.testScenario) {
+    console.error(`Provider '${providerName}' does not have testScenario configured in providers.yaml`);
+    return null;
+  }
+  
+  return {
+    provider: provider.name,
+    displayName: provider.displayName || toDisplayName(provider.name),
+    framework: framework,
+    skillName: getSkillName(provider),
+    prompt: buildPrompt(provider, framework as Framework),
+  };
+}
+
+/**
+ * List all providers from config file
+ * Returns array of provider names with display names
+ */
+export function listProviders(configFile: string): Array<{ name: string; displayName: string; hasTestScenario: boolean }> {
+  const providers = loadConfigFile(configFile);
+  
+  return Array.from(providers.values())
+    .map(p => ({
+      name: p.name,
+      displayName: p.displayName || toDisplayName(p.name),
+      hasTestScenario: !!p.testScenario,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * List providers formatted for CLI output
+ */
+export function listProvidersFormatted(configFile: string): string {
+  const providers = listProviders(configFile);
+  
+  return providers
+    .map(p => {
+      const status = p.hasTestScenario ? '' : ' (no testScenario)';
+      return `  ${p.name.padEnd(25)} ${p.displayName}${status}`;
+    })
+    .join('\n');
+}

--- a/scripts/skill-generator/lib/types.ts
+++ b/scripts/skill-generator/lib/types.ts
@@ -2,7 +2,27 @@
  * Type definitions for the skill generator
  */
 
-export type Command = 'generate' | 'review';
+export type Command = 'generate' | 'review' | 'scenario' | 'list-providers';
+
+/**
+ * Test scenario configuration for agent testing
+ */
+export interface TestScenario {
+  events: string[];       // Events to mention in test prompt
+  prompt?: string;        // Custom prompt template (optional, uses default if not specified)
+  skillName?: string;     // Override skill name (e.g., for hookdeck-event-gateway)
+}
+
+/**
+ * Output of the scenario command - used by test-agent-scenario.sh
+ */
+export interface ScenarioConfig {
+  provider: string;       // Provider name (e.g., "stripe")
+  displayName: string;    // Display name (e.g., "Stripe")
+  framework: string;      // Framework (e.g., "express", "nextjs", "fastapi")
+  skillName: string;      // Skill directory name (e.g., "stripe-webhooks")
+  prompt: string;         // The full prompt to send to the agent
+}
 
 /**
  * Provider configuration (from CLI or config file)
@@ -18,6 +38,7 @@ export interface ProviderConfig {
     [key: string]: string | undefined; // Additional doc URLs (e.g., reference_impl)
   };
   notes?: string;         // Hints for the agent
+  testScenario?: TestScenario; // Configuration for agent testing
 }
 
 /**

--- a/scripts/test-agent-scenario.sh
+++ b/scripts/test-agent-scenario.sh
@@ -2,6 +2,9 @@
 
 # Test Agent Scenario
 # Runs a specific agent test scenario using Claude Code CLI
+# 
+# Usage: ./test-agent-scenario.sh <provider> <framework> [options]
+# Example: ./test-agent-scenario.sh stripe express --dry-run
 
 set -e
 
@@ -9,6 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 TEST_DIR="/tmp/webhook-skills-agent-test"
 RESULTS_DIR="$ROOT_DIR/test-results"
+CONFIG_FILE="$ROOT_DIR/providers.yaml"
 
 # Colors
 RED='\033[0;31m'
@@ -17,163 +21,163 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
+# Check for required tools
+check_dependencies() {
+    if ! command -v jq &> /dev/null; then
+        echo -e "${RED}Error: jq is required but not installed.${NC}"
+        echo "Install with: brew install jq (macOS) or apt-get install jq (Linux)"
+        exit 1
+    fi
+}
+
+# Pre-flight check for Claude CLI
+# Verifies Claude is installed, can connect to API, and responds within timeout
+preflight_claude_check() {
+    local timeout_seconds=15
+    
+    echo -e "${BLUE}Pre-flight check: Claude CLI...${NC}"
+    
+    # Check if Claude CLI is installed
+    if ! command -v claude &> /dev/null; then
+        echo -e "${RED}Error: Claude CLI is not installed.${NC}"
+        echo "Install from: https://claude.ai/download"
+        return 1
+    fi
+    
+    local version
+    version=$(claude --version 2>&1)
+    echo -e "  Version: ${GREEN}$version${NC}"
+    
+    # Test network connectivity to Anthropic API
+    echo -e "  Testing API connectivity..."
+    if command -v curl &> /dev/null; then
+        if ! curl -s --max-time 5 https://api.anthropic.com > /dev/null 2>&1; then
+            echo -e "${YELLOW}  Warning: Cannot reach api.anthropic.com${NC}"
+            echo -e "  This may indicate network issues or firewall restrictions."
+            echo -e "  The test will continue but may fail if Claude cannot connect."
+        fi
+    fi
+    
+    # Quick test of Claude CLI with timeout
+    echo -e "  Testing Claude CLI response (${timeout_seconds}s timeout)..."
+    local test_output
+    local test_exit_code
+    
+    # Use timeout command if available, otherwise use a background process approach
+    if command -v timeout &> /dev/null; then
+        test_output=$(timeout "$timeout_seconds" claude -p "Reply with only: OK" 2>&1)
+        test_exit_code=$?
+    elif command -v gtimeout &> /dev/null; then
+        # macOS with coreutils installed
+        test_output=$(gtimeout "$timeout_seconds" claude -p "Reply with only: OK" 2>&1)
+        test_exit_code=$?
+    else
+        # Fallback for macOS without coreutils: use background process
+        claude -p "Reply with only: OK" > /tmp/claude_preflight_test.$$ 2>&1 &
+        local pid=$!
+        local count=0
+        while kill -0 $pid 2>/dev/null && [ $count -lt $timeout_seconds ]; do
+            sleep 1
+            ((count++))
+        done
+        if kill -0 $pid 2>/dev/null; then
+            kill $pid 2>/dev/null
+            wait $pid 2>/dev/null
+            test_exit_code=124  # Simulate timeout exit code
+            test_output="Command timed out"
+        else
+            wait $pid
+            test_exit_code=$?
+            test_output=$(cat /tmp/claude_preflight_test.$$ 2>/dev/null)
+        fi
+        rm -f /tmp/claude_preflight_test.$$
+    fi
+    
+    if [ $test_exit_code -eq 124 ]; then
+        echo -e "${RED}  Error: Claude CLI timed out after ${timeout_seconds}s${NC}"
+        echo -e "  This may indicate:"
+        echo -e "    - Network/firewall blocking Anthropic API"
+        echo -e "    - API authentication issues (try: claude logout && claude login)"
+        echo -e "    - Anthropic API service issues"
+        echo -e "    - Running in a sandboxed environment without network access"
+        return 1
+    elif [ $test_exit_code -ne 0 ]; then
+        echo -e "${RED}  Error: Claude CLI failed (exit code: $test_exit_code)${NC}"
+        echo -e "  Output: $test_output"
+        return 1
+    fi
+    
+    echo -e "  ${GREEN}Claude CLI is working${NC}"
+    return 0
+}
+
 usage() {
-    echo "Usage: $0 <scenario> [options]"
+    echo "Usage: $0 <provider> <framework> [options]"
     echo ""
-    echo "Available scenarios:"
-    echo "  chargebee-express  - Chargebee webhook handling in Express"
-    echo "  clerk-express      - Clerk webhook handling in Express"
-    echo "  deepgram-express   - Deepgram webhook handling in Express"
-    echo "  elevenlabs-express - ElevenLabs webhook handling in Express"
-    echo "  fusionauth-express - FusionAuth webhook handling in Express"
-    echo "  fusionauth-nextjs  - FusionAuth webhook handling in Next.js"
-    echo "  fusionauth-fastapi - FusionAuth webhook handling in FastAPI"
-    echo "  github-fastapi     - GitHub webhook handling in FastAPI"
-    echo "  hookdeck-express   - Hookdeck Event Gateway in Express"
-    echo "  openai-express     - OpenAI webhook handling in Express"
-    echo "  paddle-express     - Paddle webhook handling in Express"
-    echo "  paddle-nextjs      - Paddle webhook handling in Next.js"
-    echo "  paddle-fastapi     - Paddle webhook handling in FastAPI"
-    echo "  resend-express     - Resend webhook handling in Express"
-    echo "  resend-nextjs      - Resend webhook handling in Next.js"
-    echo "  resend-fastapi     - Resend webhook handling in FastAPI"
-    echo "  sendgrid-express   - SendGrid webhook handling in Express"
-    echo "  shopify-nextjs     - Shopify webhook handling in Next.js"
-    echo "  stripe-express     - Stripe webhook handling in Express"
+    echo "Example: $0 stripe express"
+    echo ""
+    echo "Frameworks: express, nextjs, fastapi"
+    echo ""
+    # List providers from YAML dynamically (list-providers already includes header)
+    "$SCRIPT_DIR/generate-skills.sh" list-providers --config "$CONFIG_FILE" 2>/dev/null || {
+        echo "Available providers:"
+        echo -e "${YELLOW}  (Could not load providers from config)${NC}"
+        echo "  Run from repository root or check that providers.yaml exists"
+    }
     echo ""
     echo "Options:"
     echo "  --dry-run    Show what would be done without executing"
     echo "  --verbose    Show more detailed Claude output"
-    echo "  --sandbox    Run in Docker sandbox (safer, isolated environment)"
+    echo "  -h, --help   Show this help message"
     exit 1
 }
 
-# Get scenario config
+# Get scenario config from providers.yaml via generate-skills.sh
 get_scenario_config() {
-    local scenario=$1
-    case $scenario in
-        chargebee-express)
-            PROVIDER="chargebee"
-            FRAMEWORK="express"
-            SKILL_NAME="chargebee-webhooks"
-            PROMPT="Add Chargebee webhook handling to my Express app. I want to handle subscription_created and payment_succeeded events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        clerk-express)
-            PROVIDER="clerk"
-            FRAMEWORK="express"
-            SKILL_NAME="clerk-webhooks"
-            PROMPT="Add Clerk webhook handling to my Express app. I want to handle user.created and user.updated events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        elevenlabs-express)
-            PROVIDER="elevenlabs"
-            FRAMEWORK="express"
-            SKILL_NAME="elevenlabs-webhooks"
-            PROMPT="Add ElevenLabs webhook handling to my Express app. I want to handle post_call_transcription events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        openai-express)
-            PROVIDER="openai"
-            FRAMEWORK="express"
-            SKILL_NAME="openai-webhooks"
-            PROMPT="Add OpenAI webhook handling to my Express app. I want to handle fine_tuning.job.succeeded and batch.completed events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        sendgrid-express)
-            PROVIDER="sendgrid"
-            FRAMEWORK="express"
-            SKILL_NAME="sendgrid-webhooks"
-            PROMPT="Add SendGrid webhook handling to my Express app. I want to handle delivered and bounce events for email tracking. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        stripe-express)
-            PROVIDER="stripe"
-            FRAMEWORK="express"
-            SKILL_NAME="stripe-webhooks"
-            PROMPT="Add Stripe webhook handling to my Express app. I want to handle payment_intent.succeeded events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        shopify-nextjs)
-            PROVIDER="shopify"
-            FRAMEWORK="nextjs"
-            SKILL_NAME="shopify-webhooks"
-            PROMPT="Add a Shopify webhook endpoint to handle orders/create events in my Next.js app. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        github-fastapi)
-            PROVIDER="github"
-            FRAMEWORK="fastapi"
-            SKILL_NAME="github-webhooks"
-            PROMPT="Add a GitHub webhook endpoint to my FastAPI app. I need to handle push and pull_request events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        paddle-express)
-            PROVIDER="paddle"
-            FRAMEWORK="express"
-            SKILL_NAME="paddle-webhooks"
-            PROMPT="Add Paddle webhook handling to my Express app. I want to handle subscription.created and transaction.completed events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        paddle-nextjs)
-            PROVIDER="paddle"
-            FRAMEWORK="nextjs"
-            SKILL_NAME="paddle-webhooks"
-            PROMPT="Add a Paddle webhook endpoint to handle subscription events in my Next.js app. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        paddle-fastapi)
-            PROVIDER="paddle"
-            FRAMEWORK="fastapi"
-            SKILL_NAME="paddle-webhooks"
-            PROMPT="Add a Paddle webhook endpoint to my FastAPI app. I need to handle subscription.created and subscription.canceled events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        resend-express)
-            PROVIDER="resend"
-            FRAMEWORK="express"
-            SKILL_NAME="resend-webhooks"
-            PROMPT="Add Resend webhook handling to my Express app. I want to handle email.delivered and email.bounced events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        resend-nextjs)
-            PROVIDER="resend"
-            FRAMEWORK="nextjs"
-            SKILL_NAME="resend-webhooks"
-            PROMPT="Add a Resend webhook endpoint to handle email events in my Next.js app. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        resend-fastapi)
-            PROVIDER="resend"
-            FRAMEWORK="fastapi"
-            SKILL_NAME="resend-webhooks"
-            PROMPT="Add a Resend webhook endpoint to my FastAPI app. I need to handle email.sent and email.bounced events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        deepgram-express)
-            PROVIDER="deepgram"
-            FRAMEWORK="express"
-            SKILL_NAME="deepgram-webhooks"
-            PROMPT="Add Deepgram webhook handling to my Express app. I want to receive transcription callbacks and verify the dg-token header. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        fusionauth-express)
-            PROVIDER="fusionauth"
-            FRAMEWORK="express"
-            SKILL_NAME="fusionauth-webhooks"
-            PROMPT="Add FusionAuth webhook handling to my Express app. I want to handle user.create and user.login.success events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        fusionauth-nextjs)
-            PROVIDER="fusionauth"
-            FRAMEWORK="nextjs"
-            SKILL_NAME="fusionauth-webhooks"
-            PROMPT="Add a FusionAuth webhook endpoint to handle user events in my Next.js app. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        fusionauth-fastapi)
-            PROVIDER="fusionauth"
-            FRAMEWORK="fastapi"
-            SKILL_NAME="fusionauth-webhooks"
-            PROMPT="Add a FusionAuth webhook endpoint to my FastAPI app. I need to handle user.create and user.delete events. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        hookdeck-express)
-            PROVIDER="hookdeck"
-            FRAMEWORK="express"
-            SKILL_NAME="hookdeck-event-gateway"
-            PROMPT="Create an Express webhook handler that receives webhooks forwarded through Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from providers and forwards them to my app, adding an x-hookdeck-signature header for verification. I need to verify this signature using HMAC SHA-256 with base64 encoding. If you use any skills to help with this, add a comment in the code noting which skill(s) you referenced."
-            ;;
-        *)
-            return 1
-            ;;
-    esac
+    local provider=$1
+    local framework=$2
+    
+    # Call the scenario command to get JSON config
+    # Capture stderr separately to avoid npm warnings polluting the JSON output
+    local config_json
+    local error_output
+    error_output=$("$SCRIPT_DIR/generate-skills.sh" scenario "$provider" "$framework" --config "$CONFIG_FILE" 2>&1 1>/dev/null)
+    config_json=$("$SCRIPT_DIR/generate-skills.sh" scenario "$provider" "$framework" --config "$CONFIG_FILE" 2>/dev/null)
+    local exit_code=$?
+    
+    if [ $exit_code -ne 0 ]; then
+        echo -e "${RED}Error getting scenario config:${NC}"
+        echo "$error_output"
+        return 1
+    fi
+    
+    # Validate JSON before parsing
+    if ! echo "$config_json" | jq empty 2>/dev/null; then
+        echo -e "${RED}Error: Invalid JSON response from scenario command${NC}"
+        echo "$config_json"
+        return 1
+    fi
+    
+    # Parse JSON response
+    PROVIDER=$(echo "$config_json" | jq -r '.provider')
+    DISPLAY_NAME=$(echo "$config_json" | jq -r '.displayName')
+    FRAMEWORK=$(echo "$config_json" | jq -r '.framework')
+    SKILL_NAME=$(echo "$config_json" | jq -r '.skillName')
+    PROMPT=$(echo "$config_json" | jq -r '.prompt')
+    
+    # Validate we got valid data
+    if [ "$PROVIDER" = "null" ] || [ -z "$PROVIDER" ]; then
+        echo -e "${RED}Error: Invalid config returned${NC}"
+        echo "$config_json"
+        return 1
+    fi
+    
+    return 0
 }
 
 # Parse arguments
-SCENARIO=""
+PROVIDER_ARG=""
+FRAMEWORK_ARG=""
 DRY_RUN=false
 VERBOSE=false
 
@@ -190,27 +194,58 @@ while [[ $# -gt 0 ]]; do
         -h|--help)
             usage
             ;;
+        -*)
+            echo -e "${RED}Unknown option: $1${NC}"
+            usage
+            ;;
         *)
-            SCENARIO="$1"
+            if [ -z "$PROVIDER_ARG" ]; then
+                PROVIDER_ARG="$1"
+            elif [ -z "$FRAMEWORK_ARG" ]; then
+                FRAMEWORK_ARG="$1"
+            else
+                echo -e "${RED}Too many arguments${NC}"
+                usage
+            fi
             shift
             ;;
     esac
 done
 
-if [ -z "$SCENARIO" ]; then
+# Check dependencies
+check_dependencies
+
+# Validate arguments
+if [ -z "$PROVIDER_ARG" ] || [ -z "$FRAMEWORK_ARG" ]; then
+    echo -e "${RED}Error: Both provider and framework are required${NC}"
+    echo ""
     usage
 fi
 
-if ! get_scenario_config "$SCENARIO"; then
-    echo -e "${RED}Error: Unknown scenario '$SCENARIO'${NC}"
-    usage
+# Validate framework
+case $FRAMEWORK_ARG in
+    express|nextjs|fastapi)
+        ;;
+    *)
+        echo -e "${RED}Error: Invalid framework '$FRAMEWORK_ARG'${NC}"
+        echo "Supported frameworks: express, nextjs, fastapi"
+        exit 1
+        ;;
+esac
+
+# Get scenario configuration from providers.yaml
+if ! get_scenario_config "$PROVIDER_ARG" "$FRAMEWORK_ARG"; then
+    exit 1
 fi
+
+# Create scenario name for directory/logging
+SCENARIO="${PROVIDER}-${FRAMEWORK}"
 
 echo "========================================"
 echo -e "  ${BLUE}Agent Test: $SCENARIO${NC}"
 echo "========================================"
 echo ""
-echo -e "Provider:  ${GREEN}$PROVIDER${NC}"
+echo -e "Provider:  ${GREEN}$DISPLAY_NAME${NC} ($PROVIDER)"
 echo -e "Framework: ${GREEN}$FRAMEWORK${NC}"
 echo -e "Skill:     ${GREEN}$SKILL_NAME${NC}"
 echo -e "Prompt:    $PROMPT"
@@ -361,7 +396,7 @@ run_agent() {
 
 ## Configuration
 
-- **Provider:** $PROVIDER
+- **Provider:** $DISPLAY_NAME ($PROVIDER)
 - **Framework:** $FRAMEWORK
 - **Skill:** $SKILL_NAME
 
@@ -419,6 +454,17 @@ EOF
 }
 
 # Main execution
+
+# Run pre-flight check for Claude CLI (skip for dry-run)
+if [ "$DRY_RUN" != true ]; then
+    if ! preflight_claude_check; then
+        echo -e "\n${RED}Pre-flight check failed. Aborting test.${NC}"
+        echo -e "Use --dry-run to skip this check and see what would be executed."
+        exit 1
+    fi
+    echo ""
+fi
+
 init_project
 install_skill
 run_agent


### PR DESCRIPTION
## Summary

- Refactor `test-agent-scenario.sh` to read test configurations dynamically from `providers.yaml` instead of hardcoded scenarios
- Add new CLI commands (`scenario`, `list-providers`) to support dynamic configuration
- Add pre-flight check for Claude CLI to detect network/auth issues early (fails in ~15s instead of hanging 20+ min)
- Add `hookdeck-event-gateway` provider entry

## Changes

### providers.yaml
- Added `testScenario` field to each provider with `events` and optional custom `prompt`
- New `hookdeck-event-gateway` provider entry

### test-agent-scenario.sh  
- Now accepts `<provider> <framework>` as two separate arguments (was `<provider>-<framework>`)
- Reads configuration from `providers.yaml` via new CLI commands
- Pre-flight check tests Claude CLI connectivity with 15s timeout
- No more hardcoded scenarios - adding tests only requires updating `providers.yaml`

### New files
- `scripts/skill-generator/lib/scenario.ts` - scenario configuration logic

### Documentation
- Updated `AGENTS.md` with new syntax and `providers.yaml` configuration
- Updated `TESTING.md` with agent testing documentation

## Test plan

- [x] `./scripts/test-agent-scenario.sh --help` lists providers dynamically
- [x] `./scripts/test-agent-scenario.sh stripe express --dry-run` shows correct config
- [x] `./scripts/test-agent-scenario.sh openai express` completes successfully (45s)
- [x] Pre-flight check fails fast (~15s) when Claude CLI can't connect

Made with [Cursor](https://cursor.com)