### PR TITLE
docs: IS_SANDBOX=1 generator note + normative Hookdeck CLI invocation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,23 +208,20 @@ metadata:
 
 ## Local Development
 
-For local webhook testing, install Hookdeck CLI:
+For local webhook testing, run the Hookdeck CLI via `npx` — no install required, one paste-and-run line:
 
 ```bash
-# Install via npm
-npm install -g hookdeck-cli
-
-# Or via Homebrew
-brew install hookdeck/hookdeck/hookdeck
+npx hookdeck-cli listen 3000 {provider} --path /webhooks/{provider}
 ```
 
-Then start the tunnel:
+**Conventions for this command in skill examples (apply to every example README and any `references/setup.md` that mentions a tunnel):**
 
-```bash
-hookdeck listen 3000 --path /webhooks/{provider}
-```
+- Always use `npx hookdeck-cli` (not bare `hookdeck`) — skills shouldn't push a global install of a provider-specific CLI. `npx` resolves to the package's `hookdeck` bin automatically.
+- Always pass the **source name** as the second positional arg (e.g. `stripe`, `mailgun`). The CLI's `[source]` argument is required syntactically and otherwise prompts interactively; passing it explicitly gives a copy-paste-runnable command.
+- Match the example's port: `3000` for Express and Next.js, `8000` for FastAPI.
+- The path is `/webhooks/{provider}` matching the example handler's route.
 
-No account required. Provides local tunnel + web UI for inspecting requests.
+No account required — the CLI creates a guest account on first run and provides a local tunnel + web UI for inspecting requests.
 
 ## Related Skills
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -755,6 +755,23 @@ providers:
 
 The test script reads scenarios from `providers.yaml` dynamically - no script modifications needed.
 
+## Running the Generator in Sandboxed Environments
+
+When invoking `./scripts/generate-skills.sh generate` or `review` from a sandboxed agent environment (Claude Code on the web, Docker containers, etc.), the spawned `claude` CLI passes `--dangerously-skip-permissions` to skip its interactive permission prompts. The CLI refuses that flag when the process is running as root for safety, so the run fails immediately on every provider with:
+
+```
+--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
+```
+
+Acknowledge the sandbox by exporting `IS_SANDBOX=1` for the generator invocation. The env var is inherited by the `claude` child processes and unblocks the flag:
+
+```bash
+IS_SANDBOX=1 ./scripts/generate-skills.sh generate {provider} --config providers.yaml
+IS_SANDBOX=1 ./scripts/generate-skills.sh review --config providers.yaml --create-pr=draft
+```
+
+Always pair `IS_SANDBOX=1` with an explicit `--model` (e.g. `--model claude-opus-4-7`) — the adapter's default is pinned to an older Opus build.
+
 ## Reviewing a Provider Skill or PR
 
 When reviewing a provider skill (e.g. from a pull request or before merging):

--- a/README.md
+++ b/README.md
@@ -30,21 +30,33 @@ Skills for receiving and verifying webhooks from specific providers. Each includ
 | Provider | Skill | What It Does |
 |----------|-------|--------------|
 | Chargebee | [`chargebee-webhooks`](skills/chargebee-webhooks/) | Receive and verify Chargebee webhooks (Basic Auth), handle subscription billing events |
+| Claude Managed Agents | [`claude-managed-agents-webhooks`](skills/claude-managed-agents-webhooks/) | Verify Anthropic Claude Managed Agents webhook signatures (`X-Webhook-Signature`), handle session lifecycle and outcome evaluation events |
 | Clerk | [`clerk-webhooks`](skills/clerk-webhooks/) | Verify Clerk webhook signatures, handle user, session, and organization events |
 | Cursor | [`cursor-webhooks`](skills/cursor-webhooks/) | Verify Cursor Cloud Agent webhook signatures, handle agent status events |
 | Deepgram | [`deepgram-webhooks`](skills/deepgram-webhooks/) | Receive and verify Deepgram transcription callbacks |
+| Discord | [`discord-webhooks`](skills/discord-webhooks/) | Verify Discord webhook event signatures (Ed25519), handle application and entitlement events |
 | ElevenLabs | [`elevenlabs-webhooks`](skills/elevenlabs-webhooks/) | Verify ElevenLabs webhook signatures, handle call transcription events |
 | FusionAuth | [`fusionauth-webhooks`](skills/fusionauth-webhooks/) | Verify FusionAuth JWT webhook signatures, handle user, login, and registration events |
+| Google Gemini | [`gemini-webhooks`](skills/gemini-webhooks/) | Verify Gemini API webhook signatures (Standard Webhooks HMAC + JWKS modes), handle batch and long-running operation events |
 | GitHub | [`github-webhooks`](skills/github-webhooks/) | Verify GitHub webhook signatures, handle push, pull_request, and issue events |
 | GitLab | [`gitlab-webhooks`](skills/gitlab-webhooks/) | Verify GitLab webhook tokens, handle push, merge_request, issue, and pipeline events |
+| Hugging Face | [`huggingface-webhooks`](skills/huggingface-webhooks/) | Authenticate Hugging Face webhooks (`X-Webhook-Secret`), handle repo, discussion, and comment events |
+| HubSpot | [`hubspot-webhooks`](skills/hubspot-webhooks/) | Verify HubSpot v3 webhook signatures (HMAC-SHA256 with timestamp), handle contact, deal, and company events |
+| Intercom | [`intercom-webhooks`](skills/intercom-webhooks/) | Verify Intercom webhook signatures (HMAC-SHA1, `X-Hub-Signature`), handle conversation and user events |
+| Linear | [`linear-webhooks`](skills/linear-webhooks/) | Verify Linear webhook signatures (HMAC-SHA256), handle issue, comment, and project events |
+| Mailgun | [`mailgun-webhooks`](skills/mailgun-webhooks/) | Verify Mailgun webhook signatures (HMAC-SHA256 over timestamp+token), handle delivery, open, click, and bounce events |
+| Notion | [`notion-webhooks`](skills/notion-webhooks/) | Verify Notion webhook signatures (HMAC-SHA256, `X-Notion-Signature`), complete handshake, handle page and comment events |
 | OpenAI | [`openai-webhooks`](skills/openai-webhooks/) | Verify OpenAI webhooks for fine-tuning, batch, and realtime async events |
 | Paddle | [`paddle-webhooks`](skills/paddle-webhooks/) | Verify Paddle webhook signatures, handle subscription and billing events |
+| PayPal | [`paypal-webhooks`](skills/paypal-webhooks/) | Verify PayPal webhook signatures (RSA-SHA256 with cert), handle payment, subscription, and order events |
 | Postmark | [`postmark-webhooks`](skills/postmark-webhooks/) | Authenticate Postmark webhooks (Basic Auth/Token), handle email delivery, bounce, open, click, and spam events |
 | Replicate | [`replicate-webhooks`](skills/replicate-webhooks/) | Verify Replicate webhook signatures, handle ML prediction lifecycle events |
 | Resend | [`resend-webhooks`](skills/resend-webhooks/) | Verify Resend webhook signatures, handle email delivery and bounce events |
 | SendGrid | [`sendgrid-webhooks`](skills/sendgrid-webhooks/) | Verify SendGrid webhook signatures (ECDSA), handle email delivery events |
 | Shopify | [`shopify-webhooks`](skills/shopify-webhooks/) | Verify Shopify HMAC signatures, handle order and product webhook events |
+| Slack | [`slack-webhooks`](skills/slack-webhooks/) | Verify Slack Events API signatures (HMAC-SHA256, `X-Slack-Signature`), handle message, app_mention, and reaction events |
 | Stripe | [`stripe-webhooks`](skills/stripe-webhooks/) | Verify Stripe webhook signatures, parse payment event payloads, handle checkout.session.completed events |
+| Twilio | [`twilio-webhooks`](skills/twilio-webhooks/) | Verify Twilio webhook signatures (HMAC-SHA1, `X-Twilio-Signature`), handle SMS, voice, and status callback events |
 | Vercel | [`vercel-webhooks`](skills/vercel-webhooks/) | Verify Vercel webhook signatures (HMAC-SHA1), handle deployment and project events |
 | Webflow | [`webflow-webhooks`](skills/webflow-webhooks/) | Verify Webflow webhook signatures (HMAC-SHA256), handle form submission, ecommerce, and CMS events |
 | WooCommerce | [`woocommerce-webhooks`](skills/woocommerce-webhooks/) | Verify WooCommerce webhook signatures, handle order, product, and customer events |

--- a/README.md
+++ b/README.md
@@ -30,33 +30,22 @@ Skills for receiving and verifying webhooks from specific providers. Each includ
 | Provider | Skill | What It Does |
 |----------|-------|--------------|
 | Chargebee | [`chargebee-webhooks`](skills/chargebee-webhooks/) | Receive and verify Chargebee webhooks (Basic Auth), handle subscription billing events |
-| Claude Managed Agents | [`claude-managed-agents-webhooks`](skills/claude-managed-agents-webhooks/) | Verify Anthropic Claude Managed Agents webhook signatures (`X-Webhook-Signature`), handle session lifecycle and outcome evaluation events |
 | Clerk | [`clerk-webhooks`](skills/clerk-webhooks/) | Verify Clerk webhook signatures, handle user, session, and organization events |
 | Cursor | [`cursor-webhooks`](skills/cursor-webhooks/) | Verify Cursor Cloud Agent webhook signatures, handle agent status events |
 | Deepgram | [`deepgram-webhooks`](skills/deepgram-webhooks/) | Receive and verify Deepgram transcription callbacks |
-| Discord | [`discord-webhooks`](skills/discord-webhooks/) | Verify Discord webhook event signatures (Ed25519), handle application and entitlement events |
 | ElevenLabs | [`elevenlabs-webhooks`](skills/elevenlabs-webhooks/) | Verify ElevenLabs webhook signatures, handle call transcription events |
 | FusionAuth | [`fusionauth-webhooks`](skills/fusionauth-webhooks/) | Verify FusionAuth JWT webhook signatures, handle user, login, and registration events |
-| Google Gemini | [`gemini-webhooks`](skills/gemini-webhooks/) | Verify Gemini API webhook signatures (Standard Webhooks HMAC + JWKS modes), handle batch and long-running operation events |
 | GitHub | [`github-webhooks`](skills/github-webhooks/) | Verify GitHub webhook signatures, handle push, pull_request, and issue events |
 | GitLab | [`gitlab-webhooks`](skills/gitlab-webhooks/) | Verify GitLab webhook tokens, handle push, merge_request, issue, and pipeline events |
-| Hugging Face | [`huggingface-webhooks`](skills/huggingface-webhooks/) | Authenticate Hugging Face webhooks (`X-Webhook-Secret`), handle repo, discussion, and comment events |
-| HubSpot | [`hubspot-webhooks`](skills/hubspot-webhooks/) | Verify HubSpot v3 webhook signatures (HMAC-SHA256 with timestamp), handle contact, deal, and company events |
-| Intercom | [`intercom-webhooks`](skills/intercom-webhooks/) | Verify Intercom webhook signatures (HMAC-SHA1, `X-Hub-Signature`), handle conversation and user events |
-| Linear | [`linear-webhooks`](skills/linear-webhooks/) | Verify Linear webhook signatures (HMAC-SHA256), handle issue, comment, and project events |
-| Mailgun | [`mailgun-webhooks`](skills/mailgun-webhooks/) | Verify Mailgun webhook signatures (HMAC-SHA256 over timestamp+token), handle delivery, open, click, and bounce events |
-| Notion | [`notion-webhooks`](skills/notion-webhooks/) | Verify Notion webhook signatures (HMAC-SHA256, `X-Notion-Signature`), complete handshake, handle page and comment events |
 | OpenAI | [`openai-webhooks`](skills/openai-webhooks/) | Verify OpenAI webhooks for fine-tuning, batch, and realtime async events |
+| OpenClaw | [`openclaw-webhooks`](skills/openclaw-webhooks/) | Verify OpenClaw Gateway webhook tokens, handle agent hook and wake event payloads |
 | Paddle | [`paddle-webhooks`](skills/paddle-webhooks/) | Verify Paddle webhook signatures, handle subscription and billing events |
-| PayPal | [`paypal-webhooks`](skills/paypal-webhooks/) | Verify PayPal webhook signatures (RSA-SHA256 with cert), handle payment, subscription, and order events |
 | Postmark | [`postmark-webhooks`](skills/postmark-webhooks/) | Authenticate Postmark webhooks (Basic Auth/Token), handle email delivery, bounce, open, click, and spam events |
 | Replicate | [`replicate-webhooks`](skills/replicate-webhooks/) | Verify Replicate webhook signatures, handle ML prediction lifecycle events |
 | Resend | [`resend-webhooks`](skills/resend-webhooks/) | Verify Resend webhook signatures, handle email delivery and bounce events |
 | SendGrid | [`sendgrid-webhooks`](skills/sendgrid-webhooks/) | Verify SendGrid webhook signatures (ECDSA), handle email delivery events |
 | Shopify | [`shopify-webhooks`](skills/shopify-webhooks/) | Verify Shopify HMAC signatures, handle order and product webhook events |
-| Slack | [`slack-webhooks`](skills/slack-webhooks/) | Verify Slack Events API signatures (HMAC-SHA256, `X-Slack-Signature`), handle message, app_mention, and reaction events |
 | Stripe | [`stripe-webhooks`](skills/stripe-webhooks/) | Verify Stripe webhook signatures, parse payment event payloads, handle checkout.session.completed events |
-| Twilio | [`twilio-webhooks`](skills/twilio-webhooks/) | Verify Twilio webhook signatures (HMAC-SHA1, `X-Twilio-Signature`), handle SMS, voice, and status callback events |
 | Vercel | [`vercel-webhooks`](skills/vercel-webhooks/) | Verify Vercel webhook signatures (HMAC-SHA1), handle deployment and project events |
 | Webflow | [`webflow-webhooks`](skills/webflow-webhooks/) | Verify Webflow webhook signatures (HMAC-SHA256), handle form submission, ecommerce, and CMS events |
 | WooCommerce | [`woocommerce-webhooks`](skills/woocommerce-webhooks/) | Verify WooCommerce webhook signatures, handle order, product, and customer events |

--- a/providers.yaml
+++ b/providers.yaml
@@ -160,6 +160,23 @@ providers:
         - fine_tuning.job.succeeded
         - batch.completed
 
+  - name: openclaw
+    displayName: OpenClaw
+    docs:
+      webhooks: https://docs.openclaw.ai/automation/webhook
+      hooks: https://docs.openclaw.ai/automation/hooks
+      configuration: https://docs.openclaw.ai/gateway/configuration
+    notes: >
+      Open-source autonomous AI agent platform. Uses token-based authentication
+      (not HMAC signatures). Token sent via Authorization: Bearer <token> or
+      x-openclaw-token header. Two hook types: agent hooks (/hooks/agent) trigger
+      isolated agent turns, wake hooks (/hooks/wake) enqueue system events.
+      No official webhook verification SDK — use timing-safe string comparison.
+    testScenario:
+      events:
+        - agent hook
+        - wake hook
+
   - name: paddle
     displayName: Paddle
     docs:
@@ -306,296 +323,22 @@ providers:
         - order.created
         - order.updated
 
-  - name: claude-managed-agents
-    displayName: Claude Managed Agents
-    docs:
-      webhooks: https://platform.claude.com/docs/en/managed-agents/webhooks
-      overview: https://platform.claude.com/docs/en/managed-agents/overview
-      cookbook: https://platform.claude.com/cookbook/managed-agents-cma-operate-in-production
-    notes: >
-      Anthropic Claude Managed Agents (CMA) webhooks notify your app of long-running
-      agent session state changes without holding an HTTP connection open. Uses
-      X-Webhook-Signature header with HMAC-SHA256. Signing secret is a 32-byte
-      whsec_-prefixed value generated at endpoint creation (shown only once).
-      Set ANTHROPIC_WEBHOOK_SIGNING_KEY env var. The official Anthropic SDK provides
-      client.beta.webhooks.unwrap() (Python/TS/Go/C#/Java/PHP/Ruby) which verifies the
-      signature, rejects payloads older than 5 minutes, and parses the event in one step.
-      Event payloads return only event type + id — fetch the full object via GET.
-      Endpoint must return 2xx; anything else (including 3xx) triggers retry.
-      Common events:
-      session.status_run_started, session.status_idled, session.status_rescheduled,
-      session.status_terminated, session.thread_created, session.thread_idled,
-      session.thread_terminated, session.outcome_evaluation_ended,
-      vault.created, vault.archived, vault.deleted,
-      vault_credential.created, vault_credential.archived, vault_credential.deleted,
-      vault_credential.refresh_failed.
-    testScenario:
-      events:
-        - session.status_idled
-        - session.outcome_evaluation_ended
-
-  - name: discord
-    displayName: Discord
-    docs:
-      webhooks: https://docs.discord.com/developers/events/webhook-events
-      verification: https://docs.discord.com/developers/interactions/overview#setting-up-an-endpoint-validating-security-request-headers
-    notes: >
-      Communications platform. Outgoing webhook events (and Interactions endpoints) are
-      verified using Ed25519 asymmetric signatures with X-Signature-Ed25519 (hex) and
-      X-Signature-Timestamp headers. Signed content is the concatenation of
-      X-Signature-Timestamp + raw request body. Use tweetnacl/discord-interactions
-      (Node) or PyNaCl (Python). Endpoint must respond to PING events for endpoint
-      validation. Common events: APPLICATION_AUTHORIZED, APPLICATION_DEAUTHORIZED,
-      ENTITLEMENT_CREATE, LOBBY_MESSAGE_CREATE, GAME_DIRECT_MESSAGE_CREATE.
-    testScenario:
-      events:
-        - APPLICATION_AUTHORIZED
-        - ENTITLEMENT_CREATE
-
-  - name: gemini
-    displayName: Google Gemini
-    docs:
-      webhooks: https://ai.google.dev/gemini-api/docs/webhooks
-      cookbook: https://github.com/google-gemini/cookbook/blob/main/quickstarts/Webhooks.ipynb
-      announcement: https://blog.google/innovation-and-ai/technology/developers-tools/event-driven-webhooks/
-    notes: >
-      Google Gemini API event-driven webhooks (launched May 4, 2026) push notifications
-      when long-running operations (batch jobs, video generation, Interactions API
-      function-calling LROs) complete, replacing polling. Strictly follows the Standard
-      Webhooks (Svix) spec with headers: webhook-id, webhook-timestamp, webhook-signature.
-      Two signing modes:
-      (1) Static webhooks — symmetric HMAC-SHA256 over webhook-id.webhook-timestamp.body
-      using a shared secret returned once at creation (project-level integration). Use
-      the standardwebhooks library.
-      (2) Dynamic webhooks — asymmetric RS256 JWTs verified against Google's JWKS
-      endpoint at https://generativelanguage.googleapis.com/.well-known/jwks.json
-      (per-job binding, supports user_metadata for custom routing). Reject payloads
-      older than 5 minutes. At-least-once delivery with 24-hour exponential backoff
-      retries. Common events: batch.succeeded, batch.failed, video.generated,
-      interaction.completed, interaction.requires_action.
-    testScenario:
-      events:
-        - batch.succeeded
-        - video.generated
-
-  - name: huggingface
-    displayName: Hugging Face
-    docs:
-      webhooks: https://huggingface.co/docs/hub/webhooks
-      verification: https://huggingface.co/docs/hub/webhooks#webhook-secret
-    notes: >
-      AI model hub. Webhooks notify on repository changes (models, datasets, Spaces),
-      discussions, Pull Requests, and comments. Uses a shared secret token sent in
-      the X-Webhook-Secret request header — verify with timing-safe string comparison
-      (NOT HMAC; the secret is sent verbatim). The secret can alternatively be passed
-      as a ?secret= query parameter on the handler URL. Configure in webhook settings.
-      Payload shape: top-level "event" object with "action" (create/update/delete/move)
-      and "scope" (repo, repo.content, repo.config, discussion, discussion.comment),
-      plus "repo", optional "discussion", "comment", "updatedRefs", "updatedConfig",
-      and "webhook" (with version). Rate limit: 1,000 triggers per 24 hours.
-    testScenario:
-      events:
-        - repo update (scope=repo, action=update)
-        - new discussion comment (scope=discussion.comment, action=create)
-
-  - name: hubspot
-    displayName: HubSpot
-    docs:
-      webhooks: https://developers.hubspot.com/docs/apps/legacy-apps/authentication/validating-requests
-      changelog_v3: https://developers.hubspot.com/changelog/introducing-version-3-of-webhook-signatures
-    notes: >
-      CRM platform. Uses X-HubSpot-Signature-v3 header — HMAC-SHA256 then base64
-      encoded. Signed content for v3 is the UTF-8 concatenation of HTTP method +
-      request URI (with URL-decoded chars except '?') + raw request body +
-      X-HubSpot-Request-Timestamp value. Reject requests with timestamp older than
-      5 minutes. v1 and v2 (SHA-256 of clientSecret+body, no timestamp) are deprecated
-      — new integrations should use v3 only. Signing key is the App's Client Secret
-      (Application Secret). Common subscription types: contact.creation,
-      contact.propertyChange, contact.deletion, deal.creation, deal.propertyChange,
-      company.creation, ticket.creation. (Note: the v3 validation page is canonically
-      hosted under /docs/apps/legacy-apps/authentication/validating-requests — the
-      legacy-apps label refers to HubSpot's pre-2026 app platform, but v3 signature
-      verification itself is current. A v4 webhooks API is in beta on the new
-      developer platform but uses different mechanics; pin to v3 for stability.)
-    testScenario:
-      events:
-        - contact.creation
-        - deal.creation
-
-  - name: intercom
-    displayName: Intercom
-    docs:
-      webhooks: https://developers.intercom.com/docs/webhooks
-      setup: https://developers.intercom.com/docs/webhooks/setting-up-webhooks
-      events: https://developers.intercom.com/docs/references/2.13/webhooks/webhook-models
-    notes: >
-      Customer messaging platform. Uses X-Hub-Signature header (Facebook-style) with
-      HMAC-SHA1 (40-byte hex). Format: "sha1=<hex_digest>". Computed using HMAC-SHA1
-      over the raw JSON request body with your app's client_secret (from Basic Info
-      page in the Intercom Developer Hub) as the key. Subscribe to "topics" — examples:
-      conversation.user.created, conversation.user.replied, conversation.admin.replied,
-      conversation.admin.assigned, contact.created, contact.tag.created, ticket.created,
-      ping (handshake).
-    testScenario:
-      events:
-        - conversation.user.created
-        - conversation.user.replied
-
-  - name: linear
-    displayName: Linear
-    docs:
-      webhooks: https://linear.app/developers/webhooks
-    notes: >
-      Issue tracking platform. Uses Linear-Signature header with HMAC-SHA256 (hex
-      encoded) computed over the raw body using the webhook's signing secret (shown
-      once when the webhook is created in Linear settings). Additional headers:
-      Linear-Event identifies the entity type (Issue, Comment, Project, Cycle,
-      Issue SLA, Issue attachment, Issue label, Comment reaction, Document, Initiative,
-      Customer, User), Linear-Delivery is a UUID v4 for idempotency, plus
-      Content-Type: application/json and User-Agent: Linear-Webhook. Payload includes
-      a webhookTimestamp field — reject if it's more than 1 minute old. Payload action
-      values: create, update, remove.
-    testScenario:
-      events:
-        - Issue create
-        - Comment create
-
-  - name: mailgun
-    displayName: Mailgun
-    docs:
-      webhooks: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhooks
-      configuring: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/configuring-webhooks
-      verification: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/securing-webhooks
-      payloads: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhook-payloads
-      retries: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhook-retries
-      events: https://documentation.mailgun.com/docs/mailgun/user-manual/events/events
-      event_structure: https://documentation.mailgun.com/docs/mailgun/user-manual/events/event-structure
-      api: https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/webhooks
-    notes: >
-      Email delivery platform. Webhooks can be configured at the account level
-      (apply across all domains on the account) or at the domain level (per-sending-domain),
-      but BOTH use the same signature scheme and the same Webhook Signing Key — this is
-      one skill, not two. Signature is delivered inside the request body (not a header)
-      as a top-level "signature" object with three fields: timestamp (seconds since
-      epoch), token (randomly generated 50-char string), and signature (hex). Verify
-      by computing HMAC-SHA256 over the concatenation timestamp+token (no separator)
-      using your Mailgun HTTP Webhook Signing Key, then comparing the hex digest to
-      the signature field with timing-safe comparison. For subaccounts, payloads
-      additionally include a parent-signature field signed with the parent account's
-      key — verify both when relevant. Cache tokens to drop replays; optionally
-      reject very stale timestamps but stay lenient (delivery can lag). Common event
-      types: accepted, rejected, delivered, failed (with severity: permanent or
-      temporary), opened, clicked, unsubscribed, complained, stored,
-      list_member_uploaded.
-    testScenario:
-      events:
-        - delivered
-        - failed
-
-  - name: notion
-    displayName: Notion
-    docs:
-      webhooks: https://developers.notion.com/reference/webhooks
-    notes: >
-      Productivity workspace. Webhooks launched in the 2026-03-01 API release. Uses
-      X-Notion-Signature header with HMAC-SHA256, formatted as "sha256=<hex_digest>",
-      computed over the raw request body using your integration's verification_token
-      as the signing key. Subscription activation requires a one-time handshake: the
-      first delivery is a POST containing a verification_token in the body — extract
-      and store it (do NOT verify a signature on this first message), then use it as
-      the signing key for all subsequent signature verifications. Notion provides
-      code examples in JavaScript, Python, and Ruby. Common events:
-      page.content_updated, page.properties_updated, page.locked, page.moved,
-      comment.created, data_source.schema_updated, database.schema_updated.
-    testScenario:
-      events:
-        - page.content_updated
-        - comment.created
-
-  - name: paypal
-    displayName: PayPal
-    docs:
-      webhooks: https://developer.paypal.com/api/rest/webhooks/
-      verification: https://developer.paypal.com/api/rest/webhooks/rest/
-      events: https://developer.paypal.com/api/rest/webhooks/event-names/
-    notes: >
-      Payments platform. Uses certificate-based RSA-SHA256 signature verification — not
-      HMAC. Required request headers: paypal-transmission-id, paypal-transmission-time,
-      paypal-transmission-sig (the signature), paypal-cert-url (public cert location,
-      must resolve to a paypal.com domain), and paypal-auth-algo (e.g. "SHA256withRSA").
-      Two verification paths:
-      (1) Recommended postback: POST the captured headers, your webhook_id, and the
-      raw event body to PayPal's /v1/notifications/verify-webhook-signature endpoint
-      (requires an OAuth access token). PayPal returns verification_status.
-      (2) Offline self-verify: download the cert from paypal-cert-url, compute CRC32
-      of the raw body, build the message
-      transmissionId|transmissionTime|webhookId|crc32(body), and verify the signature
-      against the cert's public key with RSA-SHA256. Common events:
-      PAYMENT.CAPTURE.COMPLETED, PAYMENT.SALE.COMPLETED, PAYMENT.CAPTURE.REFUNDED,
-      BILLING.SUBSCRIPTION.CREATED, CHECKOUT.ORDER.APPROVED.
-    testScenario:
-      events:
-        - PAYMENT.CAPTURE.COMPLETED
-        - BILLING.SUBSCRIPTION.CREATED
-
-  - name: slack
-    displayName: Slack
-    docs:
-      webhooks: https://docs.slack.dev/apis/events-api/
-      verification: https://docs.slack.dev/authentication/verifying-requests-from-slack
-      events: https://docs.slack.dev/reference/events
-    notes: >
-      Communications platform. Slack Events API uses X-Slack-Signature header
-      formatted as "v0=<hex_sha256>" plus an X-Slack-Request-Timestamp header. Signed
-      content is the literal UTF-8 string: "v0:" + timestamp + ":" + raw_body (the
-      version, timestamp, and raw body joined by colons). Signing key is the Signing
-      Secret from your Slack App's Basic Information page. Reject if timestamp
-      differs from local time by more than 5 minutes (replay protection). The
-      url_verification challenge must be echoed back during initial endpoint setup.
-      Common events: message, app_mention, reaction_added, team_join,
-      member_joined_channel, app_home_opened.
-    testScenario:
-      events:
-        - app_mention
-        - message
-
-  - name: twilio
-    displayName: Twilio
-    docs:
-      webhooks: https://www.twilio.com/docs/usage/webhooks
-      verification: https://www.twilio.com/docs/usage/webhooks/webhooks-security
-      events: https://www.twilio.com/docs/usage/webhooks/messaging-webhooks
-    notes: >
-      Communications platform (SMS, voice, WhatsApp). Uses X-Twilio-Signature header
-      with HMAC-SHA1 (base64 encoded). For application/x-www-form-urlencoded webhooks,
-      sign the full URL + each POST parameter name+value sorted alphabetically. For
-      JSON webhooks, append the SHA-256 hash of the raw body to the URL as a bodySHA256
-      query parameter and sign that URL only. Signing key is your Twilio Auth Token.
-      Official SDKs: twilio (Node) and twilio (Python) provide validateRequest /
-      RequestValidator. Common events: incoming SMS (Messaging webhook), incoming voice
-      call (Voice URL), message status callback (queued, sent, delivered, failed),
-      recording status.
-    testScenario:
-      events:
-        - incoming SMS
-        - message status callback
-
   - name: hookdeck-event-gateway
     displayName: Hookdeck Event Gateway
     docs:
       webhooks: https://hookdeck.com/docs/verification
       setup: https://hookdeck.com/docs/receive-webhooks
     notes: >
-      Webhook infrastructure platform. Hookdeck Event Gateway receives webhooks from
+      Webhook infrastructure platform. Hookdeck Event Gateway receives webhooks from 
       providers and forwards them to your app with an x-hookdeck-signature header.
       Uses HMAC-SHA256 with base64 encoding. Signed content format is the raw request body.
     testScenario:
       events:
         - webhooks via Event Gateway
       prompt: >
-        Create a {framework} webhook handler that receives webhooks forwarded through
-        Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from
-        providers and forwards them to my app, adding an x-hookdeck-signature header for
-        verification. I need to verify this signature using HMAC SHA-256 with base64
-        encoding. If you use any skills to help with this, add a comment in the code
+        Create a {framework} webhook handler that receives webhooks forwarded through 
+        Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from 
+        providers and forwards them to my app, adding an x-hookdeck-signature header for 
+        verification. I need to verify this signature using HMAC SHA-256 with base64 
+        encoding. If you use any skills to help with this, add a comment in the code 
         noting which skill(s) you referenced.

--- a/providers.yaml
+++ b/providers.yaml
@@ -306,22 +306,250 @@ providers:
         - order.created
         - order.updated
 
+  - name: claude-managed-agents
+    displayName: Claude Managed Agents
+    docs:
+      webhooks: https://platform.claude.com/docs/en/managed-agents/webhooks
+      overview: https://platform.claude.com/docs/en/managed-agents/overview
+      cookbook: https://platform.claude.com/cookbook/managed-agents-cma-operate-in-production
+    notes: >
+      Anthropic Claude Managed Agents (CMA) webhooks notify your app of long-running
+      agent session state changes without holding an HTTP connection open. Uses
+      X-Webhook-Signature header with HMAC-SHA256. Signing secret is prefixed with whsec_.
+      Official Anthropic SDK provides client.beta.webhooks.unwrap() which verifies the
+      signature, rejects payloads older than 5 minutes, and parses the event in one step.
+      Common events: session.status_idled, session.outcome_evaluation_ended, plus
+      session lifecycle and vault credential refresh events. Endpoint must return 2xx;
+      anything else is treated as failure and retried.
+    testScenario:
+      events:
+        - session.status_idled
+        - session.outcome_evaluation_ended
+
+  - name: discord
+    displayName: Discord
+    docs:
+      webhooks: https://discord.com/developers/docs/events/webhook-events
+      verification: https://discord.com/developers/docs/interactions/overview#setting-up-an-endpoint-validating-security-request-headers
+      events: https://discord.com/developers/docs/events/webhook-events#event-types
+    notes: >
+      Communications platform. Outgoing webhook events (and interaction endpoints) are
+      verified using Ed25519 signatures with X-Signature-Ed25519 (hex) and
+      X-Signature-Timestamp headers. Signed content is timestamp + raw body. Use
+      tweetnacl (Node) or PyNaCl (Python) — Discord requires asymmetric signature
+      verification, not HMAC. Endpoint must respond 204 No Content to PING events for
+      verification. Common events: APPLICATION_AUTHORIZED, ENTITLEMENT_CREATE,
+      QUEST_USER_ENROLLMENT.
+    testScenario:
+      events:
+        - APPLICATION_AUTHORIZED
+        - ENTITLEMENT_CREATE
+
+  - name: gemini
+    displayName: Google Gemini
+    docs:
+      webhooks: https://ai.google.dev/gemini-api/docs/webhooks
+      cookbook: https://github.com/google-gemini/cookbook/blob/main/quickstarts/Webhooks.ipynb
+      announcement: https://blog.google/innovation-and-ai/technology/developers-tools/event-driven-webhooks/
+    notes: >
+      Google Gemini API event-driven webhooks (launched May 4, 2026) push notifications
+      when long-running operations (batch jobs, video generation, fine-tuning) complete,
+      replacing polling. Follows the Standard Webhooks (Svix) spec with headers:
+      webhook-id, webhook-timestamp, webhook-signature. Two signing modes:
+      (1) Static webhooks — HMAC-SHA256 over webhook-id.webhook-timestamp.body using a
+      shared secret (project-level integration). Use the standardwebhooks library.
+      (2) Dynamic webhooks — RS256 JWTs verified against Google's JWKS endpoint at
+      https://generativelanguage.googleapis.com/.well-known/jwks.json (per-job binding,
+      supports user_metadata for custom routing). Reject payloads older than 5 minutes.
+      At-least-once delivery with 24-hour exponential backoff retries.
+    testScenario:
+      events:
+        - batch.completed
+        - generate_videos.completed
+
+  - name: huggingface
+    displayName: Hugging Face
+    docs:
+      webhooks: https://huggingface.co/docs/hub/webhooks
+      verification: https://huggingface.co/docs/hub/webhooks#webhook-secret
+    notes: >
+      AI model hub. Webhooks notify on repository changes (model, dataset, Space updates,
+      discussions, comments). Uses a shared secret token sent in the X-Webhook-Secret
+      header — verify with timing-safe string comparison (not HMAC). Configure the
+      secret in webhook settings. Payload includes event.action (create/update/delete),
+      event.scope (repo/discussion/comment), and a repo object. Common events: repo
+      updates (model/dataset/space create, update, delete), discussion create,
+      discussion comment create.
+    testScenario:
+      events:
+        - repo.update
+        - discussion.comment.create
+
+  - name: hubspot
+    displayName: HubSpot
+    docs:
+      webhooks: https://developers.hubspot.com/docs/api/webhooks
+      verification: https://developers.hubspot.com/docs/api/webhooks/validating-requests
+      events: https://developers.hubspot.com/docs/api/webhooks/events
+    notes: >
+      CRM platform. Uses X-HubSpot-Signature-v3 header with HMAC-SHA256 (base64 encoded).
+      Signed content for v3 is HTTP method + request URI + raw body + X-HubSpot-Request-Timestamp
+      header. Reject requests with timestamp older than 5 minutes. v1 (legacy) is
+      SHA-256 of clientSecret+body with no timestamp — new integrations should use v3.
+      App developer's Client Secret is the signing key. Common events: contact.creation,
+      contact.propertyChange, deal.creation, deal.propertyChange, company.creation.
+    testScenario:
+      events:
+        - contact.creation
+        - deal.creation
+
+  - name: intercom
+    displayName: Intercom
+    docs:
+      webhooks: https://developers.intercom.com/docs/references/webhooks
+      verification: https://developers.intercom.com/docs/build-an-integration/learn-more/webhooks/webhook-models
+      events: https://developers.intercom.com/docs/references/webhooks/topics
+    notes: >
+      Customer messaging platform. Uses X-Hub-Signature header (Facebook-style) with
+      HMAC-SHA1 (hex encoded). Signature format is sha1=<hex_digest>. Sign with your
+      app's Client Secret over the raw request body. Common events:
+      conversation.user.created, conversation.user.replied, conversation.admin.replied,
+      user.created, contact.created, ping (handshake).
+    testScenario:
+      events:
+        - conversation.user.created
+        - conversation.user.replied
+
+  - name: linear
+    displayName: Linear
+    docs:
+      webhooks: https://developers.linear.app/docs/graphql/webhooks
+      verification: https://developers.linear.app/docs/graphql/webhooks#securing-webhooks
+    notes: >
+      Issue tracking platform. Uses Linear-Signature header with HMAC-SHA256 (hex encoded)
+      computed over the raw request body using the webhook's signing secret (from Linear
+      settings). Additional headers: Linear-Event (Issue, Comment, Project, Cycle, Reaction)
+      and Linear-Delivery (UUID for idempotency). Payload includes webhookTimestamp —
+      reject if older than 1 minute. Common events: Issue create, Issue update,
+      Comment create, Project update.
+    testScenario:
+      events:
+        - Issue create
+        - Comment create
+
+  - name: mailgun
+    displayName: Mailgun
+    docs:
+      webhooks: https://documentation.mailgun.com/docs/mailgun/user-manual/tracking-messages/
+      verification: https://documentation.mailgun.com/docs/mailgun/user-manual/tracking-messages/#securing-webhooks
+    notes: >
+      Email delivery platform. Signature is in the request body (not a header) under a
+      "signature" object with three fields: timestamp, token, signature. Verify by
+      computing HMAC-SHA256 over (timestamp + token) concatenation using your Mailgun
+      HTTP webhook signing key, then comparing to signature (hex, timing-safe). Reject
+      if timestamp is older than ~15 minutes and reject duplicate tokens for idempotency.
+      Common events: delivered, opened, clicked, unsubscribed, complained,
+      permanent_fail, temporary_fail.
+    testScenario:
+      events:
+        - delivered
+        - permanent_fail
+
+  - name: notion
+    displayName: Notion
+    docs:
+      webhooks: https://developers.notion.com/reference/webhooks
+    notes: >
+      Productivity workspace. Webhooks launched in the 2026-03-01 API release. Uses
+      X-Notion-Signature header with HMAC-SHA256 (format sha256=<hex_digest>) computed
+      over the raw request body using the integration's verification_token. The first
+      delivery is a one-time verification handshake — your endpoint must echo the
+      verification_token from the payload to activate the webhook. Common events:
+      page.created, page.updated, page.deleted, comment.created,
+      database.schema_updated, page.properties_updated.
+    testScenario:
+      events:
+        - page.created
+        - page.updated
+
+  - name: paypal
+    displayName: PayPal
+    docs:
+      webhooks: https://developer.paypal.com/api/rest/webhooks/
+      verification: https://developer.paypal.com/api/rest/webhooks/rest/#link-verifywebhooksignature
+      events: https://developer.paypal.com/api/rest/webhooks/event-names/
+    notes: >
+      Payments platform. Uses certificate-based RSA-SHA256 signature verification — not
+      HMAC. Required headers: PAYPAL-TRANSMISSION-ID, PAYPAL-TRANSMISSION-TIME,
+      PAYPAL-TRANSMISSION-SIG, PAYPAL-CERT-URL, PAYPAL-AUTH-ALGO. Two verification paths:
+      (1) Recommended: call PayPal's /v1/notifications/verify-webhook-signature API with
+      the captured headers and raw body (requires OAuth access token).
+      (2) Offline: fetch PayPal public cert from PAYPAL-CERT-URL (must be on paypal.com),
+      build the expected signature payload (transmissionId|transmissionTime|webhookId|crc32(body)),
+      and verify with RSA-SHA256. Common events: PAYMENT.CAPTURE.COMPLETED,
+      BILLING.SUBSCRIPTION.CREATED, CHECKOUT.ORDER.APPROVED, PAYMENT.CAPTURE.REFUNDED.
+    testScenario:
+      events:
+        - PAYMENT.CAPTURE.COMPLETED
+        - BILLING.SUBSCRIPTION.CREATED
+
+  - name: slack
+    displayName: Slack
+    docs:
+      webhooks: https://api.slack.com/apis/events-api
+      verification: https://api.slack.com/authentication/verifying-requests-from-slack
+      events: https://api.slack.com/events
+    notes: >
+      Communications platform. Slack Events API uses X-Slack-Signature header with
+      HMAC-SHA256 (hex encoded, format v0=<hex>) and X-Slack-Request-Timestamp header.
+      Signed content is the literal string "v0:" + timestamp + ":" + raw_body. Signing
+      secret is from your Slack App's Basic Information page. Reject if timestamp
+      differs from now by more than 5 minutes (replay protection). The url_verification
+      challenge event must be echoed back during initial endpoint setup. Common events:
+      message, app_mention, reaction_added, team_join, member_joined_channel,
+      app_home_opened.
+    testScenario:
+      events:
+        - app_mention
+        - message
+
+  - name: twilio
+    displayName: Twilio
+    docs:
+      webhooks: https://www.twilio.com/docs/usage/webhooks
+      verification: https://www.twilio.com/docs/usage/webhooks/webhooks-security
+      events: https://www.twilio.com/docs/usage/webhooks/messaging-webhooks
+    notes: >
+      Communications platform (SMS, voice, WhatsApp). Uses X-Twilio-Signature header
+      with HMAC-SHA1 (base64 encoded). For application/x-www-form-urlencoded webhooks,
+      sign the full URL + each POST parameter name+value sorted alphabetically. For
+      JSON webhooks, append the SHA-256 hash of the raw body to the URL as a bodySHA256
+      query parameter and sign that URL only. Signing key is your Twilio Auth Token.
+      Official SDKs: twilio (Node) and twilio (Python) provide validateRequest /
+      RequestValidator. Common events: incoming SMS (Messaging webhook), incoming voice
+      call (Voice URL), message status callback (queued, sent, delivered, failed),
+      recording status.
+    testScenario:
+      events:
+        - incoming SMS
+        - message status callback
+
   - name: hookdeck-event-gateway
     displayName: Hookdeck Event Gateway
     docs:
       webhooks: https://hookdeck.com/docs/verification
       setup: https://hookdeck.com/docs/receive-webhooks
     notes: >
-      Webhook infrastructure platform. Hookdeck Event Gateway receives webhooks from 
+      Webhook infrastructure platform. Hookdeck Event Gateway receives webhooks from
       providers and forwards them to your app with an x-hookdeck-signature header.
       Uses HMAC-SHA256 with base64 encoding. Signed content format is the raw request body.
     testScenario:
       events:
         - webhooks via Event Gateway
       prompt: >
-        Create a {framework} webhook handler that receives webhooks forwarded through 
-        Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from 
-        providers and forwards them to my app, adding an x-hookdeck-signature header for 
-        verification. I need to verify this signature using HMAC SHA-256 with base64 
-        encoding. If you use any skills to help with this, add a comment in the code 
+        Create a {framework} webhook handler that receives webhooks forwarded through
+        Hookdeck Event Gateway. Hookdeck is a webhook proxy - it receives webhooks from
+        providers and forwards them to my app, adding an x-hookdeck-signature header for
+        verification. I need to verify this signature using HMAC SHA-256 with base64
+        encoding. If you use any skills to help with this, add a comment in the code
         noting which skill(s) you referenced.

--- a/providers.yaml
+++ b/providers.yaml
@@ -315,12 +315,20 @@ providers:
     notes: >
       Anthropic Claude Managed Agents (CMA) webhooks notify your app of long-running
       agent session state changes without holding an HTTP connection open. Uses
-      X-Webhook-Signature header with HMAC-SHA256. Signing secret is prefixed with whsec_.
-      Official Anthropic SDK provides client.beta.webhooks.unwrap() which verifies the
+      X-Webhook-Signature header with HMAC-SHA256. Signing secret is a 32-byte
+      whsec_-prefixed value generated at endpoint creation (shown only once).
+      Set ANTHROPIC_WEBHOOK_SIGNING_KEY env var. The official Anthropic SDK provides
+      client.beta.webhooks.unwrap() (Python/TS/Go/C#/Java/PHP/Ruby) which verifies the
       signature, rejects payloads older than 5 minutes, and parses the event in one step.
-      Common events: session.status_idled, session.outcome_evaluation_ended, plus
-      session lifecycle and vault credential refresh events. Endpoint must return 2xx;
-      anything else is treated as failure and retried.
+      Event payloads return only event type + id — fetch the full object via GET.
+      Endpoint must return 2xx; anything else (including 3xx) triggers retry.
+      Common events:
+      session.status_run_started, session.status_idled, session.status_rescheduled,
+      session.status_terminated, session.thread_created, session.thread_idled,
+      session.thread_terminated, session.outcome_evaluation_ended,
+      vault.created, vault.archived, vault.deleted,
+      vault_credential.created, vault_credential.archived, vault_credential.deleted,
+      vault_credential.refresh_failed.
     testScenario:
       events:
         - session.status_idled
@@ -329,17 +337,16 @@ providers:
   - name: discord
     displayName: Discord
     docs:
-      webhooks: https://discord.com/developers/docs/events/webhook-events
-      verification: https://discord.com/developers/docs/interactions/overview#setting-up-an-endpoint-validating-security-request-headers
-      events: https://discord.com/developers/docs/events/webhook-events#event-types
+      webhooks: https://docs.discord.com/developers/events/webhook-events
+      verification: https://docs.discord.com/developers/interactions/overview#setting-up-an-endpoint-validating-security-request-headers
     notes: >
-      Communications platform. Outgoing webhook events (and interaction endpoints) are
-      verified using Ed25519 signatures with X-Signature-Ed25519 (hex) and
-      X-Signature-Timestamp headers. Signed content is timestamp + raw body. Use
-      tweetnacl (Node) or PyNaCl (Python) — Discord requires asymmetric signature
-      verification, not HMAC. Endpoint must respond 204 No Content to PING events for
-      verification. Common events: APPLICATION_AUTHORIZED, ENTITLEMENT_CREATE,
-      QUEST_USER_ENROLLMENT.
+      Communications platform. Outgoing webhook events (and Interactions endpoints) are
+      verified using Ed25519 asymmetric signatures with X-Signature-Ed25519 (hex) and
+      X-Signature-Timestamp headers. Signed content is the concatenation of
+      X-Signature-Timestamp + raw request body. Use tweetnacl/discord-interactions
+      (Node) or PyNaCl (Python). Endpoint must respond to PING events for endpoint
+      validation. Common events: APPLICATION_AUTHORIZED, APPLICATION_DEAUTHORIZED,
+      ENTITLEMENT_CREATE, LOBBY_MESSAGE_CREATE, GAME_DIRECT_MESSAGE_CREATE.
     testScenario:
       events:
         - APPLICATION_AUTHORIZED
@@ -353,19 +360,23 @@ providers:
       announcement: https://blog.google/innovation-and-ai/technology/developers-tools/event-driven-webhooks/
     notes: >
       Google Gemini API event-driven webhooks (launched May 4, 2026) push notifications
-      when long-running operations (batch jobs, video generation, fine-tuning) complete,
-      replacing polling. Follows the Standard Webhooks (Svix) spec with headers:
-      webhook-id, webhook-timestamp, webhook-signature. Two signing modes:
-      (1) Static webhooks — HMAC-SHA256 over webhook-id.webhook-timestamp.body using a
-      shared secret (project-level integration). Use the standardwebhooks library.
-      (2) Dynamic webhooks — RS256 JWTs verified against Google's JWKS endpoint at
-      https://generativelanguage.googleapis.com/.well-known/jwks.json (per-job binding,
-      supports user_metadata for custom routing). Reject payloads older than 5 minutes.
-      At-least-once delivery with 24-hour exponential backoff retries.
+      when long-running operations (batch jobs, video generation, Interactions API
+      function-calling LROs) complete, replacing polling. Strictly follows the Standard
+      Webhooks (Svix) spec with headers: webhook-id, webhook-timestamp, webhook-signature.
+      Two signing modes:
+      (1) Static webhooks — symmetric HMAC-SHA256 over webhook-id.webhook-timestamp.body
+      using a shared secret returned once at creation (project-level integration). Use
+      the standardwebhooks library.
+      (2) Dynamic webhooks — asymmetric RS256 JWTs verified against Google's JWKS
+      endpoint at https://generativelanguage.googleapis.com/.well-known/jwks.json
+      (per-job binding, supports user_metadata for custom routing). Reject payloads
+      older than 5 minutes. At-least-once delivery with 24-hour exponential backoff
+      retries. Common events: batch.succeeded, batch.failed, video.generated,
+      interaction.completed, interaction.requires_action.
     testScenario:
       events:
-        - batch.completed
-        - generate_videos.completed
+        - batch.succeeded
+        - video.generated
 
   - name: huggingface
     displayName: Hugging Face
@@ -373,31 +384,39 @@ providers:
       webhooks: https://huggingface.co/docs/hub/webhooks
       verification: https://huggingface.co/docs/hub/webhooks#webhook-secret
     notes: >
-      AI model hub. Webhooks notify on repository changes (model, dataset, Space updates,
-      discussions, comments). Uses a shared secret token sent in the X-Webhook-Secret
-      header — verify with timing-safe string comparison (not HMAC). Configure the
-      secret in webhook settings. Payload includes event.action (create/update/delete),
-      event.scope (repo/discussion/comment), and a repo object. Common events: repo
-      updates (model/dataset/space create, update, delete), discussion create,
-      discussion comment create.
+      AI model hub. Webhooks notify on repository changes (models, datasets, Spaces),
+      discussions, Pull Requests, and comments. Uses a shared secret token sent in
+      the X-Webhook-Secret request header — verify with timing-safe string comparison
+      (NOT HMAC; the secret is sent verbatim). The secret can alternatively be passed
+      as a ?secret= query parameter on the handler URL. Configure in webhook settings.
+      Payload shape: top-level "event" object with "action" (create/update/delete/move)
+      and "scope" (repo, repo.content, repo.config, discussion, discussion.comment),
+      plus "repo", optional "discussion", "comment", "updatedRefs", "updatedConfig",
+      and "webhook" (with version). Rate limit: 1,000 triggers per 24 hours.
     testScenario:
       events:
-        - repo.update
-        - discussion.comment.create
+        - repo update (scope=repo, action=update)
+        - new discussion comment (scope=discussion.comment, action=create)
 
   - name: hubspot
     displayName: HubSpot
     docs:
-      webhooks: https://developers.hubspot.com/docs/api/webhooks
-      verification: https://developers.hubspot.com/docs/api/webhooks/validating-requests
-      events: https://developers.hubspot.com/docs/api/webhooks/events
+      webhooks: https://developers.hubspot.com/docs/apps/legacy-apps/authentication/validating-requests
+      changelog_v3: https://developers.hubspot.com/changelog/introducing-version-3-of-webhook-signatures
     notes: >
-      CRM platform. Uses X-HubSpot-Signature-v3 header with HMAC-SHA256 (base64 encoded).
-      Signed content for v3 is HTTP method + request URI + raw body + X-HubSpot-Request-Timestamp
-      header. Reject requests with timestamp older than 5 minutes. v1 (legacy) is
-      SHA-256 of clientSecret+body with no timestamp — new integrations should use v3.
-      App developer's Client Secret is the signing key. Common events: contact.creation,
-      contact.propertyChange, deal.creation, deal.propertyChange, company.creation.
+      CRM platform. Uses X-HubSpot-Signature-v3 header — HMAC-SHA256 then base64
+      encoded. Signed content for v3 is the UTF-8 concatenation of HTTP method +
+      request URI (with URL-decoded chars except '?') + raw request body +
+      X-HubSpot-Request-Timestamp value. Reject requests with timestamp older than
+      5 minutes. v1 and v2 (SHA-256 of clientSecret+body, no timestamp) are deprecated
+      — new integrations should use v3 only. Signing key is the App's Client Secret
+      (Application Secret). Common subscription types: contact.creation,
+      contact.propertyChange, contact.deletion, deal.creation, deal.propertyChange,
+      company.creation, ticket.creation. (Note: the v3 validation page is canonically
+      hosted under /docs/apps/legacy-apps/authentication/validating-requests — the
+      legacy-apps label refers to HubSpot's pre-2026 app platform, but v3 signature
+      verification itself is current. A v4 webhooks API is in beta on the new
+      developer platform but uses different mechanics; pin to v3 for stability.)
     testScenario:
       events:
         - contact.creation
@@ -406,15 +425,17 @@ providers:
   - name: intercom
     displayName: Intercom
     docs:
-      webhooks: https://developers.intercom.com/docs/references/webhooks
-      verification: https://developers.intercom.com/docs/build-an-integration/learn-more/webhooks/webhook-models
-      events: https://developers.intercom.com/docs/references/webhooks/topics
+      webhooks: https://developers.intercom.com/docs/webhooks
+      setup: https://developers.intercom.com/docs/webhooks/setting-up-webhooks
+      events: https://developers.intercom.com/docs/references/2.13/webhooks/webhook-models
     notes: >
       Customer messaging platform. Uses X-Hub-Signature header (Facebook-style) with
-      HMAC-SHA1 (hex encoded). Signature format is sha1=<hex_digest>. Sign with your
-      app's Client Secret over the raw request body. Common events:
+      HMAC-SHA1 (40-byte hex). Format: "sha1=<hex_digest>". Computed using HMAC-SHA1
+      over the raw JSON request body with your app's client_secret (from Basic Info
+      page in the Intercom Developer Hub) as the key. Subscribe to "topics" — examples:
       conversation.user.created, conversation.user.replied, conversation.admin.replied,
-      user.created, contact.created, ping (handshake).
+      conversation.admin.assigned, contact.created, contact.tag.created, ticket.created,
+      ping (handshake).
     testScenario:
       events:
         - conversation.user.created
@@ -423,15 +444,17 @@ providers:
   - name: linear
     displayName: Linear
     docs:
-      webhooks: https://developers.linear.app/docs/graphql/webhooks
-      verification: https://developers.linear.app/docs/graphql/webhooks#securing-webhooks
+      webhooks: https://linear.app/developers/webhooks
     notes: >
-      Issue tracking platform. Uses Linear-Signature header with HMAC-SHA256 (hex encoded)
-      computed over the raw request body using the webhook's signing secret (from Linear
-      settings). Additional headers: Linear-Event (Issue, Comment, Project, Cycle, Reaction)
-      and Linear-Delivery (UUID for idempotency). Payload includes webhookTimestamp —
-      reject if older than 1 minute. Common events: Issue create, Issue update,
-      Comment create, Project update.
+      Issue tracking platform. Uses Linear-Signature header with HMAC-SHA256 (hex
+      encoded) computed over the raw body using the webhook's signing secret (shown
+      once when the webhook is created in Linear settings). Additional headers:
+      Linear-Event identifies the entity type (Issue, Comment, Project, Cycle,
+      Issue SLA, Issue attachment, Issue label, Comment reaction, Document, Initiative,
+      Customer, User), Linear-Delivery is a UUID v4 for idempotency, plus
+      Content-Type: application/json and User-Agent: Linear-Webhook. Payload includes
+      a webhookTimestamp field — reject if it's more than 1 minute old. Payload action
+      values: create, update, remove.
     testScenario:
       events:
         - Issue create
@@ -440,16 +463,18 @@ providers:
   - name: mailgun
     displayName: Mailgun
     docs:
-      webhooks: https://documentation.mailgun.com/docs/mailgun/user-manual/tracking-messages/
-      verification: https://documentation.mailgun.com/docs/mailgun/user-manual/tracking-messages/#securing-webhooks
+      webhooks: https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/webhooks
+      verification: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/securing-webhooks
     notes: >
-      Email delivery platform. Signature is in the request body (not a header) under a
-      "signature" object with three fields: timestamp, token, signature. Verify by
-      computing HMAC-SHA256 over (timestamp + token) concatenation using your Mailgun
-      HTTP webhook signing key, then comparing to signature (hex, timing-safe). Reject
-      if timestamp is older than ~15 minutes and reject duplicate tokens for idempotency.
-      Common events: delivered, opened, clicked, unsubscribed, complained,
-      permanent_fail, temporary_fail.
+      Email delivery platform. Signature is delivered inside the request body (not a
+      header) as a top-level "signature" object with three fields: timestamp (seconds
+      since epoch), token (randomly generated 50-char string), and signature (hex).
+      Verify by computing HMAC-SHA256 over the concatenation timestamp+token (no
+      separator) using your Mailgun HTTP Webhook Signing Key, then comparing the
+      resulting hex digest to the signature field with timing-safe comparison. Cache
+      tokens to drop replays and optionally reject very stale timestamps (be lenient
+      — there can be processing delay). Common events: delivered, opened, clicked,
+      unsubscribed, complained, permanent_fail, temporary_fail.
     testScenario:
       events:
         - delivered
@@ -461,33 +486,41 @@ providers:
       webhooks: https://developers.notion.com/reference/webhooks
     notes: >
       Productivity workspace. Webhooks launched in the 2026-03-01 API release. Uses
-      X-Notion-Signature header with HMAC-SHA256 (format sha256=<hex_digest>) computed
-      over the raw request body using the integration's verification_token. The first
-      delivery is a one-time verification handshake — your endpoint must echo the
-      verification_token from the payload to activate the webhook. Common events:
-      page.created, page.updated, page.deleted, comment.created,
-      database.schema_updated, page.properties_updated.
+      X-Notion-Signature header with HMAC-SHA256, formatted as "sha256=<hex_digest>",
+      computed over the raw request body using your integration's verification_token
+      as the signing key. Subscription activation requires a one-time handshake: the
+      first delivery is a POST containing a verification_token in the body — extract
+      and store it (do NOT verify a signature on this first message), then use it as
+      the signing key for all subsequent signature verifications. Notion provides
+      code examples in JavaScript, Python, and Ruby. Common events:
+      page.content_updated, page.properties_updated, page.locked, page.moved,
+      comment.created, data_source.schema_updated, database.schema_updated.
     testScenario:
       events:
-        - page.created
-        - page.updated
+        - page.content_updated
+        - comment.created
 
   - name: paypal
     displayName: PayPal
     docs:
       webhooks: https://developer.paypal.com/api/rest/webhooks/
-      verification: https://developer.paypal.com/api/rest/webhooks/rest/#link-verifywebhooksignature
+      verification: https://developer.paypal.com/api/rest/webhooks/rest/
       events: https://developer.paypal.com/api/rest/webhooks/event-names/
     notes: >
       Payments platform. Uses certificate-based RSA-SHA256 signature verification — not
-      HMAC. Required headers: PAYPAL-TRANSMISSION-ID, PAYPAL-TRANSMISSION-TIME,
-      PAYPAL-TRANSMISSION-SIG, PAYPAL-CERT-URL, PAYPAL-AUTH-ALGO. Two verification paths:
-      (1) Recommended: call PayPal's /v1/notifications/verify-webhook-signature API with
-      the captured headers and raw body (requires OAuth access token).
-      (2) Offline: fetch PayPal public cert from PAYPAL-CERT-URL (must be on paypal.com),
-      build the expected signature payload (transmissionId|transmissionTime|webhookId|crc32(body)),
-      and verify with RSA-SHA256. Common events: PAYMENT.CAPTURE.COMPLETED,
-      BILLING.SUBSCRIPTION.CREATED, CHECKOUT.ORDER.APPROVED, PAYMENT.CAPTURE.REFUNDED.
+      HMAC. Required request headers: paypal-transmission-id, paypal-transmission-time,
+      paypal-transmission-sig (the signature), paypal-cert-url (public cert location,
+      must resolve to a paypal.com domain), and paypal-auth-algo (e.g. "SHA256withRSA").
+      Two verification paths:
+      (1) Recommended postback: POST the captured headers, your webhook_id, and the
+      raw event body to PayPal's /v1/notifications/verify-webhook-signature endpoint
+      (requires an OAuth access token). PayPal returns verification_status.
+      (2) Offline self-verify: download the cert from paypal-cert-url, compute CRC32
+      of the raw body, build the message
+      transmissionId|transmissionTime|webhookId|crc32(body), and verify the signature
+      against the cert's public key with RSA-SHA256. Common events:
+      PAYMENT.CAPTURE.COMPLETED, PAYMENT.SALE.COMPLETED, PAYMENT.CAPTURE.REFUNDED,
+      BILLING.SUBSCRIPTION.CREATED, CHECKOUT.ORDER.APPROVED.
     testScenario:
       events:
         - PAYMENT.CAPTURE.COMPLETED
@@ -496,18 +529,19 @@ providers:
   - name: slack
     displayName: Slack
     docs:
-      webhooks: https://api.slack.com/apis/events-api
-      verification: https://api.slack.com/authentication/verifying-requests-from-slack
-      events: https://api.slack.com/events
+      webhooks: https://docs.slack.dev/apis/events-api/
+      verification: https://docs.slack.dev/authentication/verifying-requests-from-slack
+      events: https://docs.slack.dev/reference/events
     notes: >
-      Communications platform. Slack Events API uses X-Slack-Signature header with
-      HMAC-SHA256 (hex encoded, format v0=<hex>) and X-Slack-Request-Timestamp header.
-      Signed content is the literal string "v0:" + timestamp + ":" + raw_body. Signing
-      secret is from your Slack App's Basic Information page. Reject if timestamp
-      differs from now by more than 5 minutes (replay protection). The url_verification
-      challenge event must be echoed back during initial endpoint setup. Common events:
-      message, app_mention, reaction_added, team_join, member_joined_channel,
-      app_home_opened.
+      Communications platform. Slack Events API uses X-Slack-Signature header
+      formatted as "v0=<hex_sha256>" plus an X-Slack-Request-Timestamp header. Signed
+      content is the literal UTF-8 string: "v0:" + timestamp + ":" + raw_body (the
+      version, timestamp, and raw body joined by colons). Signing key is the Signing
+      Secret from your Slack App's Basic Information page. Reject if timestamp
+      differs from local time by more than 5 minutes (replay protection). The
+      url_verification challenge must be echoed back during initial endpoint setup.
+      Common events: message, app_mention, reaction_added, team_join,
+      member_joined_channel, app_home_opened.
     testScenario:
       events:
         - app_mention

--- a/providers.yaml
+++ b/providers.yaml
@@ -463,22 +463,34 @@ providers:
   - name: mailgun
     displayName: Mailgun
     docs:
-      webhooks: https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/webhooks
+      webhooks: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhooks
+      configuring: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/configuring-webhooks
       verification: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/securing-webhooks
+      payloads: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhook-payloads
+      retries: https://documentation.mailgun.com/docs/mailgun/user-manual/webhooks/webhook-retries
+      events: https://documentation.mailgun.com/docs/mailgun/user-manual/events/events
+      event_structure: https://documentation.mailgun.com/docs/mailgun/user-manual/events/event-structure
+      api: https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/webhooks
     notes: >
-      Email delivery platform. Signature is delivered inside the request body (not a
-      header) as a top-level "signature" object with three fields: timestamp (seconds
-      since epoch), token (randomly generated 50-char string), and signature (hex).
-      Verify by computing HMAC-SHA256 over the concatenation timestamp+token (no
-      separator) using your Mailgun HTTP Webhook Signing Key, then comparing the
-      resulting hex digest to the signature field with timing-safe comparison. Cache
-      tokens to drop replays and optionally reject very stale timestamps (be lenient
-      — there can be processing delay). Common events: delivered, opened, clicked,
-      unsubscribed, complained, permanent_fail, temporary_fail.
+      Email delivery platform. Webhooks can be configured at the account level
+      (apply across all domains on the account) or at the domain level (per-sending-domain),
+      but BOTH use the same signature scheme and the same Webhook Signing Key — this is
+      one skill, not two. Signature is delivered inside the request body (not a header)
+      as a top-level "signature" object with three fields: timestamp (seconds since
+      epoch), token (randomly generated 50-char string), and signature (hex). Verify
+      by computing HMAC-SHA256 over the concatenation timestamp+token (no separator)
+      using your Mailgun HTTP Webhook Signing Key, then comparing the hex digest to
+      the signature field with timing-safe comparison. For subaccounts, payloads
+      additionally include a parent-signature field signed with the parent account's
+      key — verify both when relevant. Cache tokens to drop replays; optionally
+      reject very stale timestamps but stay lenient (delivery can lag). Common event
+      types: accepted, rejected, delivered, failed (with severity: permanent or
+      temporary), opened, clicked, unsubscribed, complained, stored,
+      list_member_uploaded.
     testScenario:
       events:
         - delivered
-        - permanent_fail
+        - failed
 
   - name: notion
     displayName: Notion

--- a/scripts/skill-generator/prompts/generate-skill.md
+++ b/scripts/skill-generator/prompts/generate-skill.md
@@ -66,6 +66,12 @@ Read the AGENTS.md file in this repository to understand the full skill creation
 3. **Include comprehensive tests** that generate real signatures using the provider's algorithm
 4. **Be idiomatic** to each framework (Express middleware patterns, Next.js App Router, FastAPI dependencies)
 5. **Return appropriate HTTP status codes** (200 for success, 400 for invalid signature, etc.)
+6. **Hookdeck CLI in example READMEs** — when an example shows how to receive webhooks locally, use exactly this form (no install step, source arg is required):
+   - Express: `npx hookdeck-cli listen 3000 {{PROVIDER_KEBAB}} --path /webhooks/{{PROVIDER_KEBAB}}`
+   - Next.js: `npx hookdeck-cli listen 3000 {{PROVIDER_KEBAB}} --path /webhooks/{{PROVIDER_KEBAB}}`
+   - FastAPI: `npx hookdeck-cli listen 8000 {{PROVIDER_KEBAB}} --path /webhooks/{{PROVIDER_KEBAB}}`
+
+   Do **not** write `hookdeck listen ...` (assumes a global install), and do **not** omit the source positional arg (the CLI would otherwise prompt interactively). See `AGENTS.md` → "Local Development" for the rationale.
 
 ## CRITICAL: Consistency Checks
 


### PR DESCRIPTION
## Summary

Two related infrastructure tweaks for skill development:

### 1. `IS_SANDBOX=1` for the generator under root

Adds a "Running the Generator in Sandboxed Environments" section to `AGENTS.md` documenting the `IS_SANDBOX=1` env var needed when running `./scripts/generate-skills.sh` from a sandboxed agent environment (Claude Code on the web, Docker containers, etc.). The CLI refuses `--dangerously-skip-permissions` under root unless `IS_SANDBOX=1` is set in the parent env (it's inherited by the spawned subprocesses).

Also reminds operators to pass `--model claude-opus-4-7` explicitly because the adapter's pinned default is stale.

### 2. Hookdeck CLI invocation: `npx hookdeck-cli listen <port> <source> --path /webhooks/<source>`

Rewrites the AGENTS.md "Local Development" section as **normative** guidance, and mirrors the rule into `scripts/skill-generator/prompts/generate-skill.md` so the generator emits the right form every time.

Two reasons for the switch from `hookdeck listen ...` (with implicit global install) to `npx hookdeck-cli listen ...`:

1. webhook-skills is provider-neutral; pushing every example reader to `npm i -g hookdeck-cli` reads as Hookdeck self-promotion. `npx` is one paste-and-run line.
2. The CLI's `[source]` positional is required syntactically — omitting it makes the command fall into an interactive prompt, so explicit commands match what users actually paste.

The 12 newly-generated skills (PRs #41–#52) and the existing 19 will be normalized to match in follow-up changes.

## Previous scope (now removed)

This branch originally also bundled `README.md` and `providers.yaml` entries for 12 new providers. Those have been split into the per-provider feat PRs so each can be reviewed and merged independently:

| PR | Provider |
|---|---|
| #41 | discord |
| #42 | claude-managed-agents |
| #43 | gemini |
| #44 | huggingface |
| #45 | hubspot |
| #46 | intercom |
| #47 | linear |
| #48 | mailgun |
| #49 | notion |
| #50 | paypal |
| #51 | slack |
| #52 | twilio |

Related: issue #53 (intermittent worktree file-placement bug in the generator).

## Test plan

- [ ] AGENTS.md changes read cleanly
- [ ] Generator prompt change applied to `generate-skill.md`
- [ ] (Optional) Generate a fresh skill under the new prompt and verify the example READMEs use `npx hookdeck-cli listen <port> <source> --path /webhooks/<source>` exactly

https://claude.ai/code/session_01NNTgQRJss1V7gyzzJ9rjnB