### PR TITLE
feat(skill-generator): per-provider SDK version-tracking via `sdks` field

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -25,6 +25,12 @@
 #     events      - Array of event types to test with
 #     prompt      - Custom prompt template (uses default if not specified)
 #     skillName   - Override skill directory name (default: {name}-webhooks)
+#   sdks          - Provider-specific SDK packages to version-track (optional):
+#     npm         - Array of npm package names (e.g., ["@paddle/paddle-node-sdk"])
+#     pip         - Array of PyPI package names (e.g., ["paddle-python-sdk"])
+#     The generator queries these alongside the generic framework deps so the
+#     AI sees current SDK versions in the {{VERSIONS_TABLE}} and can flag
+#     stale pins in package.json/requirements.txt during review.
 #
 # When adding a new provider skill:
 #   1. Add provider entry here with documentation URLs and testScenario
@@ -186,7 +192,12 @@ providers:
     notes: >
       Payment and subscription platform. Uses Paddle-Signature header with HMAC-SHA256.
       Signature format includes timestamp (ts) and hash (h1). Secret starts with pdl_ntfset_.
-      Official SDKs available: @paddle/paddle-node-sdk, paddle-billing (Python).
+      Official SDKs: @paddle/paddle-node-sdk (Node), paddle-python-sdk (Python).
+    sdks:
+      npm:
+        - "@paddle/paddle-node-sdk"
+      pip:
+        - paddle-python-sdk
     testScenario:
       events:
         - subscription.created

--- a/scripts/skill-generator/index.ts
+++ b/scripts/skill-generator/index.ts
@@ -28,7 +28,7 @@ import { generateSkill } from './lib/generator';
 import { reviewExistingSkill } from './lib/reviewer';
 import { setCachedVersions } from './lib/cli';
 import { DEFAULT_CLI_TOOL, AVAILABLE_CLI_TOOLS } from './lib/cli-adapters';
-import { getLatestVersions } from './lib/versions';
+import { getLatestVersions, collectProviderSdks } from './lib/versions';
 import {
   createWorktree,
   removeWorktree,
@@ -216,13 +216,15 @@ async function handleGenerate(
   const { dir: resultsDir } = createResultsDir();
   console.log(chalk.gray(`Results directory: ${resultsDir}\n`));
   
-  // Query latest package versions and cache them for prompts (skip in dry-run mode)
+  // Query latest package versions and cache them for prompts (skip in dry-run mode).
+  // Include per-provider SDKs declared via `sdks` in providers.yaml so the version
+  // table seen by the AI covers stale SDK pins, not just generic framework deps.
   if (!generateOptions.dryRun) {
     console.log(chalk.blue('Querying package managers for latest stable versions...'));
     const VERSIONS_TIMEOUT = 30000; // 30 seconds
     try {
       const versions = await Promise.race([
-        getLatestVersions(),
+        getLatestVersions(collectProviderSdks(providerConfigs)),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Network timeout after 30s')), VERSIONS_TIMEOUT)
         ),
@@ -501,13 +503,15 @@ async function handleReview(
   const { dir: resultsDir } = createResultsDir();
   console.log(chalk.gray(`Results directory: ${resultsDir}\n`));
   
-  // Query latest package versions and cache them for prompts (skip in dry-run mode)
+  // Query latest package versions and cache them for prompts (skip in dry-run mode).
+  // Include per-provider SDKs declared via `sdks` in providers.yaml so the version
+  // table seen by the AI covers stale SDK pins, not just generic framework deps.
   if (!reviewOptions.dryRun) {
     console.log(chalk.blue('Querying package managers for latest stable versions...'));
     const VERSIONS_TIMEOUT = 30000; // 30 seconds
     try {
       const versions = await Promise.race([
-        getLatestVersions(),
+        getLatestVersions(collectProviderSdks(providerConfigs)),
         new Promise<never>((_, reject) =>
           setTimeout(() => reject(new Error('Network timeout after 30s')), VERSIONS_TIMEOUT)
         ),

--- a/scripts/skill-generator/lib/cli.ts
+++ b/scripts/skill-generator/lib/cli.ts
@@ -6,7 +6,7 @@ import { execa, type ExecaError } from 'execa';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import type { ProviderConfig, Logger, ReviewResult } from './types';
-import { type PackageVersions, formatVersionsTable } from './versions';
+import { type PackageVersions, formatVersionsTableForProvider } from './versions';
 import { getCliAdapter, DEFAULT_CLI_TOOL } from './cli-adapters';
 
 const PROMPTS_DIR = join(__dirname, '..', 'prompts');
@@ -95,10 +95,12 @@ export function buildPromptReplacements(provider: ProviderConfig): Record<string
     }
   }
   
-  // Build versions table from cached versions (or empty if not available)
+  // Build versions table from cached versions (or empty if not available).
+  // Scoped to generic framework deps + this provider's declared `sdks`,
+  // so the prompt doesn't dump every queried SDK across all providers.
   let versionsTable = '*Version lookup not available - use latest stable versions from npm/pip*';
   if (cachedVersions) {
-    versionsTable = formatVersionsTable(cachedVersions);
+    versionsTable = formatVersionsTableForProvider(cachedVersions, provider.sdks);
   }
   
   const replacements: Record<string, string> = {

--- a/scripts/skill-generator/lib/config.ts
+++ b/scripts/skill-generator/lib/config.ts
@@ -137,6 +137,7 @@ export function loadConfigFile(filePath: string): Map<string, ProviderConfig> {
         docs: config.docs as ProviderConfig['docs'],
         notes: config.notes as string | undefined,
         testScenario: config.testScenario as TestScenario | undefined,
+        sdks: config.sdks as ProviderConfig['sdks'],
       });
     }
   } else {
@@ -145,16 +146,17 @@ export function loadConfigFile(filePath: string): Map<string, ProviderConfig> {
       if (typeof value !== 'object' || value === null) {
         continue;
       }
-      
+
       const config = value as Record<string, unknown>;
       const normalizedName = normalizeProviderName(key);
-      
+
       configs.set(normalizedName, {
         name: normalizedName,
         displayName: (config.displayName as string) || toDisplayName(key),
         docs: config.docs as ProviderConfig['docs'],
         notes: config.notes as string | undefined,
         testScenario: config.testScenario as TestScenario | undefined,
+        sdks: config.sdks as ProviderConfig['sdks'],
       });
     }
   }

--- a/scripts/skill-generator/lib/types.ts
+++ b/scripts/skill-generator/lib/types.ts
@@ -39,6 +39,18 @@ export interface ProviderConfig {
   };
   notes?: string;         // Hints for the agent
   testScenario?: TestScenario; // Configuration for agent testing
+  /**
+   * Provider-specific SDK packages to track for version-staleness review.
+   * These get queried alongside the generic framework deps and appear in
+   * {{VERSIONS_TABLE}} for both generate and review prompts, letting the
+   * reviewer flag stale SDK pins in package.json / requirements.txt.
+   * Use the canonical package-manager names (e.g., "@paddle/paddle-node-sdk"
+   * for npm, "paddle-python-sdk" for pip).
+   */
+  sdks?: {
+    npm?: string[];
+    pip?: string[];
+  };
 }
 
 /**

--- a/scripts/skill-generator/lib/versions.ts
+++ b/scripts/skill-generator/lib/versions.ts
@@ -10,8 +10,12 @@ export interface PackageVersions {
   pip: Record<string, string>;
 }
 
-const NPM_PACKAGES = ['next', 'express', 'vitest', 'jest', 'typescript'];
-const PIP_PACKAGES = ['fastapi', 'pytest', 'httpx'];
+/**
+ * Generic framework deps queried for every run. Per-provider SDK packages
+ * (declared via `sdks` in providers.yaml) are merged in at query time.
+ */
+export const NPM_PACKAGES = ['next', 'express', 'vitest', 'jest', 'typescript'];
+export const PIP_PACKAGES = ['fastapi', 'pytest', 'httpx'];
 
 /**
  * Get latest stable version from npm
@@ -53,17 +57,30 @@ async function getPipVersion(pkg: string): Promise<string | null> {
 }
 
 /**
- * Query all package versions in parallel
+ * Query all package versions in parallel.
+ *
+ * `extras` lets callers add provider-specific SDK packages (declared via the
+ * `sdks` field in providers.yaml) on top of the generic framework deps. They
+ * get queried in the same parallel batch and end up in the same
+ * `PackageVersions` object; per-provider prompts then filter the global map
+ * down to the relevant subset via `formatVersionsTableForProvider`.
  */
-export async function getLatestVersions(logger?: Logger): Promise<PackageVersions> {
+export async function getLatestVersions(
+  extras: { npm?: string[]; pip?: string[] } = {},
+  logger?: Logger,
+): Promise<PackageVersions> {
   logger?.info('Querying package managers for latest versions...');
-  
-  const npmPromises = NPM_PACKAGES.map(async pkg => {
+
+  // De-dupe so generic + per-provider lists don't double-query the same package
+  const npmList = Array.from(new Set([...NPM_PACKAGES, ...(extras.npm ?? [])]));
+  const pipList = Array.from(new Set([...PIP_PACKAGES, ...(extras.pip ?? [])]));
+
+  const npmPromises = npmList.map(async pkg => {
     const version = await getNpmVersion(pkg);
     return [pkg, version] as const;
   });
-  
-  const pipPromises = PIP_PACKAGES.map(async pkg => {
+
+  const pipPromises = pipList.map(async pkg => {
     const version = await getPipVersion(pkg);
     return [pkg, version] as const;
   });
@@ -103,18 +120,64 @@ export async function getLatestVersions(logger?: Logger): Promise<PackageVersion
 export function formatVersionsTable(versions: PackageVersions): string {
   let table = '| Package | Latest Stable | Use in package.json/requirements.txt |\n';
   table += '|---------|---------------|--------------------------------------|\n';
-  
+
   for (const [pkg, version] of Object.entries(versions.npm)) {
     // Use ^ for npm to allow minor/patch updates
     table += `| \`${pkg}\` | ${version} | \`^${version}\` |\n`;
   }
-  
+
   for (const [pkg, version] of Object.entries(versions.pip)) {
     // Use >= for pip
     table += `| \`${pkg}\` | ${version} | \`>=${version}\` |\n`;
   }
-  
+
   return table;
+}
+
+/**
+ * Format versions for a single provider — generic framework deps plus the
+ * provider's own SDKs. Used to keep prompts focused on packages relevant to
+ * the skill being generated/reviewed, rather than dumping every queried SDK
+ * across all providers.
+ */
+export function formatVersionsTableForProvider(
+  versions: PackageVersions,
+  sdks?: { npm?: string[]; pip?: string[] },
+): string {
+  const npmKeys = new Set<string>([...NPM_PACKAGES, ...(sdks?.npm ?? [])]);
+  const pipKeys = new Set<string>([...PIP_PACKAGES, ...(sdks?.pip ?? [])]);
+
+  let table = '| Package | Latest Stable | Use in package.json/requirements.txt |\n';
+  table += '|---------|---------------|--------------------------------------|\n';
+
+  for (const [pkg, version] of Object.entries(versions.npm)) {
+    if (!npmKeys.has(pkg)) continue;
+    table += `| \`${pkg}\` | ${version} | \`^${version}\` |\n`;
+  }
+
+  for (const [pkg, version] of Object.entries(versions.pip)) {
+    if (!pipKeys.has(pkg)) continue;
+    table += `| \`${pkg}\` | ${version} | \`>=${version}\` |\n`;
+  }
+
+  return table;
+}
+
+/**
+ * Collect the union of all provider-declared SDKs across a config set,
+ * de-duplicating across providers. Used at startup to expand the version
+ * query to cover every SDK that might appear in any prompt.
+ */
+export function collectProviderSdks(
+  providers: Array<{ sdks?: { npm?: string[]; pip?: string[] } }>,
+): { npm: string[]; pip: string[] } {
+  const npm = new Set<string>();
+  const pip = new Set<string>();
+  for (const p of providers) {
+    for (const pkg of p.sdks?.npm ?? []) npm.add(pkg);
+    for (const pkg of p.sdks?.pip ?? []) pip.add(pkg);
+  }
+  return { npm: Array.from(npm), pip: Array.from(pip) };
 }
 
 /**


### PR DESCRIPTION
## Summary

Lets each provider declare its own SDK packages in `providers.yaml` so the version-staleness check during generation and review actually covers provider SDKs — not just the generic framework deps (Express, FastAPI, vitest, etc.) the generator was previously hardcoded to query.

## Why

Caught while reviewing PR #58. The "Dependencies" check in `review-skill.md` (line 82) tells the AI to grade pins against `{{VERSIONS_TABLE}}`. That table is built from a hardcoded list in `scripts/skill-generator/lib/versions.ts`:

```ts
const NPM_PACKAGES = ['next', 'express', 'vitest', 'jest', 'typescript'];
const PIP_PACKAGES = ['fastapi', 'pytest', 'httpx'];
```

So when reviewing `paddle-webhooks`, the AI saw current versions for Express/Next.js/TypeScript and correctly flagged `typescript ^5.9.3` (minor — 1 major behind). But `@paddle/paddle-node-sdk` was invisible — the table never mentioned it, so the AI had no signal that `^1.4.0` was 2 majors behind `^3.8.0`. That gap is what produced the stale Paddle SDK reference in PR #58 (and was also why the original `paddle-webhooks` generation pinned `^1.4.0` to begin with).

## Schema addition

`providers.yaml` entries gain an optional `sdks` field:

```yaml
- name: paddle
  ...
  sdks:
    npm:
      - "@paddle/paddle-node-sdk"
    pip:
      - paddle-python-sdk
```

Field choice (`sdks` vs `packages`): `sdks` is more semantically specific — these are the provider's own SDK packages we want version-tracked. The generic framework deps stay covered by the hardcoded list in `versions.ts`.

Documented at the top of `providers.yaml` alongside the existing `name`/`displayName`/`docs`/`notes`/`testScenario` schema.

## Plumbing

- `types.ts` — `ProviderConfig.sdks?: { npm?: string[]; pip?: string[] }`
- `config.ts` — parser reads `sdks` from both the array and object yaml formats
- `versions.ts`:
  - Exports the generic `NPM_PACKAGES` / `PIP_PACKAGES` lists
  - `getLatestVersions(extras?: { npm; pip })` merges and de-dupes generic + per-provider lists before querying in parallel
  - `formatVersionsTableForProvider(versions, sdks)` filters the global cache down to generic deps + this provider's SDKs (avoids dumping every queried SDK across all providers into every prompt)
  - `collectProviderSdks(providers)` unions all SDKs across a config set so `index.ts` can pre-fetch the full superset once
- `cli.ts` — `buildPromptReplacements` uses the per-provider table
- `index.ts` — both `generate` and `review` call sites pass `collectProviderSdks(providerConfigs)` to the version query

## Seeded `paddle` only

The other 30+ providers' `sdks` entries can be added in a follow-up sweep — separating the mechanism from the data keeps this PR small and focused.

## Test result

Verified end-to-end. With `paddle.sdks` populated, the generator's startup log now reports:

```
Querying package managers for latest stable versions...
  npm: next@16.2.6, express@5.2.1, vitest@4.1.6, jest@30.4.2, typescript@6.0.3, @paddle/paddle-node-sdk@3.8.0
  pip: fastapi@0.136.1, pytest@9.0.3, httpx@0.28.1, paddle-python-sdk@1.14.1
```

Then running `./scripts/generate-skills.sh review paddle --config providers.yaml --model claude-opus-4-7` from this branch flagged exactly the issues we'd hope for:

- **major** — `@paddle/paddle-node-sdk ^1.4.0` in `examples/express/package.json` is 2 majors behind `^3.8.0`
- **major** — same in `examples/nextjs/package.json`
- **minor** — `paddle-python-sdk>=1.0.0` in `examples/fastapi/requirements.txt` is too loose; tighten to `>=1.14.1` (the loose pin permits versions that predate the `Verifier`/`Secret` API the docs reference)

The review iteration applied those bumps (worked output sitting on the local `improve/paddle-webhooks` branch; happy to push it as either a fresh PR or on top of PR #58 if that's helpful — see comment below).

## Test plan

- [ ] `cd scripts/skill-generator && npx tsc --noEmit` — typechecks clean
- [ ] Smoke-test the helper end-to-end (the test script in the PR's commit message reproduces it)
- [ ] Run `./scripts/generate-skills.sh review paddle --config providers.yaml` and confirm the version table in the prompt now includes both `@paddle/paddle-node-sdk` and `paddle-python-sdk`
- [ ] Run review on a provider without `sdks` declared and confirm behavior is unchanged (no SDK rows in the table, generic deps still queried)

https://claude.ai/code/session_01NNTgQRJss1V7gyzzJ9rjnB

---
_Generated by [Claude Code](https://claude.ai/code/session_01NNTgQRJss1V7gyzzJ9rjnB)_