### PR TITLE
Derive marketplace.json from skills/ (generator sync + CI drift check)

### DIFF
--- a/.github/workflows/validate-provider-pr.yml
+++ b/.github/workflows/validate-provider-pr.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'skills/**'
+      - '.claude-plugin/**'
 
 jobs:
   validate:
@@ -40,3 +41,19 @@ jobs:
           else
             echo "Some validations failed. See job output for details." >> $GITHUB_STEP_SUMMARY
           fi
+
+  manifest:
+    name: Marketplace Manifest In Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check marketplace.json is in sync with skills/
+        run: |
+          # Fails if any skill lacks a manifest entry or any entry is orphaned.
+          ./scripts/generate-skills.sh sync-marketplace --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -486,6 +486,7 @@ Use this checklist when creating a new provider skill:
 #### Integration
 - [ ] Update `README.md` - Add skill to Provider Skills table
 - [ ] Update `providers.yaml` - Add provider entry with documentation URLs and `testScenario`
+- [ ] Register in the plugin manifest: `./scripts/generate-skills.sh sync-marketplace` (the generator does this automatically; run manually for hand-authored skills)
 - [ ] Run example tests: `cd examples/express && npm test`
 - [ ] Run validation: `./scripts/validate-provider.sh {provider}-webhooks`
 - [ ] Run agent test: `./scripts/test-agent-scenario.sh {provider} express --dry-run`
@@ -554,6 +555,7 @@ Gather this information:
 7. Update integration files:
    - `README.md` - Add skill to Provider Skills table
    - `providers.yaml` - Add provider entry with `testScenario` field
+   - `.claude-plugin/marketplace.json` - Register the skill with `./scripts/generate-skills.sh sync-marketplace` (auto-run by the generator)
 8. Test with agent: `./scripts/test-agent-scenario.sh {provider} express --dry-run`
 
 ## Skill Discoverability
@@ -805,6 +807,7 @@ The automated review checks skill content and tests, but does **not** verify int
 
 1. **README.md** — Provider added to Provider Skills table
 2. **providers.yaml** — Provider entry added with documentation URLs and `testScenario` field
+3. **.claude-plugin/marketplace.json** — Skill registered as a plugin (verify with `./scripts/generate-skills.sh sync-marketplace --check`)
 
 ### Step 3: Spot-Check Skill Content
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,13 @@ All providers and their official documentation URLs are tracked in `providers.ya
 3. Update the README.md Provider Skills table
 4. Add at least one scenario to `scripts/test-agent-scenario.sh`
 
+The generator registers the new skill in `.claude-plugin/marketplace.json` automatically. For a hand-authored skill, register it (or fix any drift) with:
+
+```bash
+./scripts/generate-skills.sh sync-marketplace          # add any missing plugin entries
+./scripts/generate-skills.sh sync-marketplace --check   # report drift only (used by CI)
+```
+
 **Validate locally before pushing:**
 
 ```bash
@@ -133,7 +140,7 @@ All providers and their official documentation URLs are tracked in `providers.ya
 ./scripts/validate-provider.sh --all
 ```
 
-The CI workflow `validate-provider-pr.yml` runs this same validation automatically for new provider PRs.
+The CI workflow `validate-provider-pr.yml` runs this same validation automatically for new provider PRs, and also checks that `.claude-plugin/marketplace.json` is in sync with `skills/`.
 
 ### Acceptance Thresholds
 

--- a/scripts/skill-generator/index.ts
+++ b/scripts/skill-generator/index.ts
@@ -42,6 +42,7 @@ import {
   pathExistsInBranch,
 } from './lib/git';
 import { createPullRequest, verifyToken } from './lib/github';
+import { syncManifest, findManifestDrift } from './lib/marketplace';
 
 const ROOT_DIR = join(__dirname, '..', '..');
 
@@ -872,6 +873,47 @@ async function handleListProviders(
   }
 }
 
+/**
+ * Sync marketplace command handler
+ *
+ * Keeps .claude-plugin/marketplace.json in sync with skills/. With --check it
+ * reports drift and exits non-zero (for CI); otherwise it adds any missing
+ * plugin entries without touching existing ones.
+ */
+async function handleSyncMarketplace(
+  options: { check?: boolean }
+): Promise<void> {
+  if (options.check) {
+    const { missing, orphans } = findManifestDrift();
+    if (missing.length === 0 && orphans.length === 0) {
+      console.log(chalk.green('✅ marketplace.json is in sync with skills/'));
+      return;
+    }
+    if (missing.length > 0) {
+      console.log(chalk.red(`❌ ${missing.length} skill(s) missing a marketplace.json entry:`));
+      for (const m of missing) console.log(chalk.red(`   - skills/${m}`));
+    }
+    if (orphans.length > 0) {
+      console.log(chalk.red(`❌ ${orphans.length} marketplace.json entr(ies) point to a missing skill:`));
+      for (const o of orphans) console.log(chalk.red(`   - skills/${o}`));
+    }
+    console.log(chalk.gray('\nRun `./scripts/generate-skills.sh sync-marketplace` to add missing entries.'));
+    process.exit(1);
+  }
+
+  const { added, orphans } = syncManifest();
+  if (added.length === 0) {
+    console.log(chalk.green('✅ marketplace.json already in sync — nothing to add'));
+  } else {
+    console.log(chalk.green(`✅ Added ${added.length} entr(ies) to marketplace.json:`));
+    for (const a of added) console.log(chalk.green(`   - skills/${a}`));
+  }
+  if (orphans.length > 0) {
+    console.log(chalk.yellow(`\n⚠️  ${orphans.length} entr(ies) reference a missing skill (not removed automatically):`));
+    for (const o of orphans) console.log(chalk.yellow(`   - skills/${o}`));
+  }
+}
+
 // CLI setup
 const program = new Command();
 
@@ -928,5 +970,11 @@ program
   .requiredOption('--config <file>', 'Load provider configs from YAML file')
   .option('--json', 'Output as JSON', false)
   .action(handleListProviders);
+
+program
+  .command('sync-marketplace')
+  .description('Sync .claude-plugin/marketplace.json with skills/ (adds missing entries)')
+  .option('--check', 'Report drift and exit non-zero without writing (for CI)', false)
+  .action(handleSyncMarketplace);
 
 program.parse();

--- a/scripts/skill-generator/lib/generator.ts
+++ b/scripts/skill-generator/lib/generator.ts
@@ -26,6 +26,7 @@ import {
   getRepoInfo,
 } from './git';
 import { createPullRequest } from './github';
+import { syncManifest } from './marketplace';
 
 /**
  * Run tests for a skill
@@ -279,8 +280,18 @@ export async function generateSkill(
     
     // Commit and push from worktree
     const skillPath = getSkillPath(provider);
-    
-    await addFiles(worktreePath, [skillPath], { logger, dryRun: options.dryRun });
+
+    // Register the new skill in the plugin manifest so it can't drift from skills/.
+    const filesToStage = [skillPath];
+    if (!options.dryRun) {
+      const { added } = syncManifest(worktreePath);
+      if (added.length > 0) {
+        logger.info(`Registered ${added.length} skill(s) in marketplace.json`);
+        filesToStage.push('.claude-plugin/marketplace.json');
+      }
+    }
+
+    await addFiles(worktreePath, filesToStage, { logger, dryRun: options.dryRun });
     await commit(worktreePath, `feat: add ${provider.name}-webhooks skill`, {
       logger,
       dryRun: options.dryRun,

--- a/scripts/skill-generator/lib/marketplace.ts
+++ b/scripts/skill-generator/lib/marketplace.ts
@@ -1,0 +1,235 @@
+/**
+ * Marketplace manifest sync
+ *
+ * Keeps `.claude-plugin/marketplace.json` in sync with the skills that actually
+ * exist under `skills/`. Each skill directory that contains a SKILL.md must have
+ * a matching plugin entry in the manifest.
+ *
+ * The manifest carries hand-curated fields (short `description`, `keywords`) that
+ * are intentionally richer than what the generator produces, so this module is
+ * deliberately *non-destructive*: it only ADDS entries that are missing and never
+ * rewrites or reorders existing ones. Existing bytes are preserved exactly (new
+ * entries are spliced in as text), so adopting the tool does not churn the file.
+ *
+ * Curated fields for a newly added entry are seeded from the skill's SKILL.md
+ * frontmatter and sensible conventions; a human can refine them afterwards.
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+import { parse as parseYaml } from 'yaml';
+
+const ROOT_DIR = join(__dirname, '..', '..', '..');
+const MANIFEST_PATH = '.claude-plugin/marketplace.json';
+
+const DEFAULT_AUTHOR = { name: 'Hookdeck', email: 'phil@hookdeck.com' };
+const DEFAULT_REPOSITORY = 'https://github.com/hookdeck/webhook-skills';
+
+export interface MarketplacePlugin {
+  name: string;
+  description: string;
+  source: string;
+  strict: boolean;
+  skills: string[];
+  category: string;
+  license: string;
+  author: { name: string; email: string };
+  repository: string;
+  homepage: string;
+  keywords: string[];
+}
+
+export interface DriftReport {
+  /** Skill directories (with a SKILL.md) that have no manifest entry. */
+  missing: string[];
+  /** Manifest entries whose `source` directory no longer exists. */
+  orphans: string[];
+}
+
+function manifestFile(rootDir: string): string {
+  return join(rootDir, MANIFEST_PATH);
+}
+
+function skillsDir(rootDir: string): string {
+  return join(rootDir, 'skills');
+}
+
+/** List skill directory names (those containing a SKILL.md) under skills/. */
+export function listSkillDirs(rootDir: string = ROOT_DIR): string[] {
+  const dir = skillsDir(rootDir);
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((name) => {
+      const p = join(dir, name);
+      return statSync(p).isDirectory() && existsSync(join(p, 'SKILL.md'));
+    })
+    .sort();
+}
+
+/** Parse the YAML frontmatter block from a SKILL.md file. */
+function readFrontmatter(skillMdPath: string): Record<string, any> {
+  const content = readFileSync(skillMdPath, 'utf8');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  try {
+    return parseYaml(match[1]) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** Map the manifest set of plugin sources to their directory basenames. */
+function manifestSourceDirs(plugins: MarketplacePlugin[]): Set<string> {
+  const set = new Set<string>();
+  for (const p of plugins) {
+    const src = p.source ?? '';
+    const m = src.match(/^\.\/skills\/([^/]+)\/?$/);
+    if (m) set.add(m[1]);
+  }
+  return set;
+}
+
+/** Build a manifest entry for a skill directory from its SKILL.md + conventions. */
+export function buildEntry(rootDir: string, skillDir: string): MarketplacePlugin {
+  const fm = readFrontmatter(join(skillsDir(rootDir), skillDir, 'SKILL.md'));
+  const metadata = (fm.metadata ?? {}) as Record<string, any>;
+  const repository = typeof metadata.repository === 'string' ? metadata.repository : DEFAULT_REPOSITORY;
+  const description =
+    typeof fm.description === 'string' ? fm.description.replace(/\s+/g, ' ').trim() : '';
+  const providerKeyword = skillDir.replace(/-webhooks$/, '');
+
+  return {
+    name: typeof fm.name === 'string' ? fm.name : skillDir,
+    description,
+    source: `./skills/${skillDir}`,
+    strict: false,
+    skills: ['./'],
+    category: 'integration',
+    license: typeof fm.license === 'string' ? fm.license : 'MIT',
+    author: DEFAULT_AUTHOR,
+    repository,
+    homepage: `${repository}/tree/main/skills/${skillDir}`,
+    keywords: Array.from(new Set(['webhooks', ...providerKeyword.split('-')])).filter(Boolean),
+  };
+}
+
+/** Compare skills/ against the manifest and report drift in both directions. */
+export function findManifestDrift(rootDir: string = ROOT_DIR): DriftReport {
+  const raw = readFileSync(manifestFile(rootDir), 'utf8');
+  const data = JSON.parse(raw) as { plugins: MarketplacePlugin[] };
+  const sourced = manifestSourceDirs(data.plugins);
+  const dirs = listSkillDirs(rootDir);
+  const dirSet = new Set(dirs);
+
+  const missing = dirs.filter((d) => !sourced.has(d));
+  const orphans = Array.from(sourced).filter((d) => !dirSet.has(d)).sort();
+  return { missing, orphans };
+}
+
+/**
+ * Locate the character offset of the start of each top-level object inside the
+ * `plugins` array, tracking string/brace state so nested objects are ignored.
+ */
+function topLevelObjectOffsets(raw: string): number[] {
+  const arrStart = raw.indexOf('[', raw.indexOf('"plugins"'));
+  const offsets: number[] = [];
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  let objStart = -1;
+  for (let i = arrStart; i < raw.length; i++) {
+    const c = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (c === '\\') esc = true;
+      else if (c === '"') inStr = false;
+      continue;
+    }
+    if (c === '"') inStr = true;
+    else if (c === '{') {
+      depth++;
+      if (depth === 1) objStart = i;
+    } else if (c === '}') {
+      if (depth === 1) offsets.push(objStart);
+      depth--;
+    } else if (c === ']' && depth === 0) {
+      break;
+    }
+  }
+  return offsets;
+}
+
+/** Serialize an entry as text indented to sit inside the 4-space plugins array. */
+function renderEntryBlock(entry: MarketplacePlugin): string {
+  const json = JSON.stringify(entry, null, 2);
+  return json
+    .split('\n')
+    .map((line) => '    ' + line)
+    .join('\n');
+}
+
+export interface SyncResult {
+  added: string[];
+  orphans: string[];
+}
+
+/**
+ * Add manifest entries for any skill directories missing one, inserted
+ * alphabetically within the leading alphabetically-sorted run of entries (the
+ * provider-skills section). Existing entries are never modified or reordered.
+ * Returns the list of added skill directories. Set `dryRun` to compute without
+ * writing.
+ */
+export function syncManifest(
+  rootDir: string = ROOT_DIR,
+  opts: { dryRun?: boolean } = {}
+): SyncResult {
+  const path = manifestFile(rootDir);
+  let raw = readFileSync(path, 'utf8');
+  const data = JSON.parse(raw) as { plugins: MarketplacePlugin[] };
+  const names = data.plugins.map((p) => p.name);
+
+  const { missing, orphans } = findManifestDrift(rootDir);
+  if (missing.length === 0) return { added: [], orphans };
+
+  // The provider section is the longest strictly-increasing prefix of names;
+  // the curated non-provider plugins are appended after it out of alpha order.
+  let prefixLen = 1;
+  while (prefixLen < names.length && names[prefixLen] > names[prefixLen - 1]) prefixLen++;
+  if (names.length === 0) prefixLen = 0;
+
+  const offsets = topLevelObjectOffsets(raw);
+  const lineStart = (idx: number) => raw.lastIndexOf('\n', idx) + 1;
+
+  // Group new entries by the anchor entry they should be inserted before.
+  const entries = missing.map((d) => buildEntry(rootDir, d)).sort((a, b) => (a.name < b.name ? -1 : 1));
+  const groups = new Map<number, MarketplacePlugin[]>();
+  for (const entry of entries) {
+    let anchor = prefixLen; // default: end of provider section (before curated group)
+    for (let i = 0; i < prefixLen; i++) {
+      if (names[i] > entry.name) {
+        anchor = i;
+        break;
+      }
+    }
+    if (!groups.has(anchor)) groups.set(anchor, []);
+    groups.get(anchor)!.push(entry);
+  }
+
+  // Apply insertions from the highest offset downward so earlier offsets stay valid.
+  const anchors = Array.from(groups.keys()).sort((a, b) => b - a);
+  for (const anchor of anchors) {
+    const pos = lineStart(offsets[anchor]);
+    const block =
+      groups
+        .get(anchor)!
+        .map((e) => renderEntryBlock(e))
+        .join(',\n') + ',\n';
+    raw = raw.slice(0, pos) + block + raw.slice(pos);
+  }
+
+  // Validate before writing.
+  JSON.parse(raw);
+  if (!opts.dryRun) writeFileSync(path, raw);
+  return { added: missing.slice(), orphans };
+}

--- a/scripts/validate-provider.sh
+++ b/scripts/validate-provider.sh
@@ -233,13 +233,24 @@ validate_integration() {
   else
     errors+=("providers.yaml not found at repository root")
   fi
-  
+
+  # Check the plugin manifest has a registration for this skill.
+  # Entries reference the skill via "source": "./skills/<provider>".
+  local manifest="$ROOT_DIR/.claude-plugin/marketplace.json"
+  if [ -f "$manifest" ]; then
+    if ! grep -q "\"\\./skills/$provider\"" "$manifest"; then
+      errors+=("$provider not registered in .claude-plugin/marketplace.json (run: ./scripts/generate-skills.sh sync-marketplace)")
+    fi
+  else
+    errors+=(".claude-plugin/marketplace.json not found at repository root")
+  fi
+
   # Return errors
   if [ ${#errors[@]} -gt 0 ]; then
     printf '%s\n' "${errors[@]}"
     return 1
   fi
-  
+
   return 0
 }
 


### PR DESCRIPTION
## Problem

`.claude-plugin/marketplace.json` is the plugin manifest, but it was **hand-maintained** and duplicated data already derivable from `skills/` (name, description) plus pure boilerplate (source, homepage, author, license). Nothing kept it in sync, so it silently drifted — a newly generated skill would ship without a manifest entry and nobody would notice until someone tried to install it.

## Approach

Make the manifest a **derived, drift-checked** artifact instead of a hand-maintained one — without churning the existing file.

- **`lib/marketplace.ts`** — a *non-destructive* sync. It adds a plugin entry for any skill directory (one with a `SKILL.md`) that lacks one, seeded from the skill's SKILL.md frontmatter + repo conventions, spliced in **alphabetically within the provider section as text**. Existing entries are never rewritten or reordered, so the curated short `description`/`keywords` on current entries are preserved and the diff stays purely additive. Also reports orphans (entries whose `source` dir no longer exists).
- **`sync-marketplace` generator command** — `./scripts/generate-skills.sh sync-marketplace` (write) and `--check` (report drift, exit non-zero for CI).
- **Generator wiring** — `generateSkill` now runs the sync after producing a skill and stages `.claude-plugin/marketplace.json` in the same `feat: add <provider>-webhooks skill` commit. This is the root-cause fix: previously only the `skills/<provider>-webhooks` dir was staged.
- **CI / validation** —
  - `validate-provider.sh` now fails a provider if it isn't registered in the manifest (zero-dep grep check; runs in the existing `--detect-new` PR gate).
  - A new `manifest` job in `validate-provider-pr.yml` runs `sync-marketplace --check` to catch orphans and any drift, and the workflow trigger now also fires on `.claude-plugin/**`.
- **Docs** — AGENTS.md and CONTRIBUTING.md reference the tool in the add-a-provider and review checklists.

## Why non-destructive (not a full regenerate)

The current manifest mixes curated one-line descriptions and keyword sets that are intentionally richer than the SKILL.md discovery blurbs, and it carries curated non-provider plugins (`webhook-handler-patterns`, `hookdeck-event-gateway`, `outpost`, …). A full regenerate would reword those and normalize incidental formatting (the file even has inconsistent Unicode escaping between entries). Additive sync keeps curation and human control while guaranteeing no skill is left unregistered.

## Testing

Verified locally against the generator's own repo state:
- `--check` passes on an in-sync tree; exits non-zero and lists the offender when a skill is added without an entry, or when an entry is orphaned.
- Write mode adds the missing entry in the correct alphabetical position, produces a **purely additive** diff (no existing lines changed), valid JSON, and is idempotent (re-running is a no-op).
- `tsc --noEmit` passes; `validate-provider.sh` still passes for existing providers with the new manifest check.

## Note

This is intentionally scoped to the tooling only (branched from `main`) so it reviews independently of the "add 17 skills" PR (#69). Once both land, the 17 skills added there are already registered in the manifest; this tool keeps them — and everything future — from drifting again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkRuaGgYUz9q4k3yokqWKm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkRuaGgYUz9q4k3yokqWKm)_