### PR TITLE
fix: skill generator leaves README/providers.yaml/marketplace.json uncommitted

### DIFF
--- a/scripts/skill-generator/index.ts
+++ b/scripts/skill-generator/index.ts
@@ -714,7 +714,14 @@ async function handleReview(
           const commitVerb = isNewSkill ? 'add' : 'improve';
           const commitMessage = `${commitPrefix}: ${commitVerb} ${provider.name}-webhooks skill`;
           
-          await addFiles(workingDir, [skillPath], { logger, dryRun: reviewOptions.dryRun });
+          // Stage integration files too (README row, providers.yaml entry,
+          // marketplace registration) — validate-provider.sh requires them,
+          // and git add is a no-op for unmodified paths.
+          await addFiles(
+            workingDir,
+            [skillPath, 'README.md', 'providers.yaml', '.claude-plugin/marketplace.json'],
+            { logger, dryRun: reviewOptions.dryRun }
+          );
           await commit(workingDir, commitMessage, {
             logger,
             dryRun: reviewOptions.dryRun,

--- a/scripts/skill-generator/lib/generator.ts
+++ b/scripts/skill-generator/lib/generator.ts
@@ -282,14 +282,25 @@ export async function generateSkill(
     const skillPath = getSkillPath(provider);
 
     // Register the new skill in the plugin manifest so it can't drift from skills/.
-    const filesToStage = [skillPath];
     if (!options.dryRun) {
       const { added } = syncManifest(worktreePath);
       if (added.length > 0) {
         logger.info(`Registered ${added.length} skill(s) in marketplace.json`);
-        filesToStage.push('.claude-plugin/marketplace.json');
       }
     }
+
+    // Stage the integration files alongside the skill. The AI updates
+    // README.md and providers.yaml per CONTRIBUTING/AGENTS conventions, and
+    // marketplace.json may already be registered by the AI (in which case
+    // syncManifest reports nothing added) — validate-provider.sh requires all
+    // three, so a commit without them produces a PR that always fails CI.
+    // git add is a no-op for unmodified paths.
+    const filesToStage = [
+      skillPath,
+      'README.md',
+      'providers.yaml',
+      '.claude-plugin/marketplace.json',
+    ];
 
     await addFiles(worktreePath, filesToStage, { logger, dryRun: options.dryRun });
     await commit(worktreePath, `feat: add ${provider.name}-webhooks skill`, {


### PR DESCRIPTION
## Summary

The `generate` and `review` commands stage only `skills/{provider}-webhooks` when committing (plus `.claude-plugin/marketplace.json` only in the narrow case where the generator's own `syncManifest` added the entry). The generation AI updates `README.md`, `providers.yaml`, and usually `marketplace.json` in the worktree per CONTRIBUTING/AGENTS conventions, but those changes never make it into the commit.

Result: every generator-created PR fails `validate-provider-pr.yml` with:

```
- {provider}-webhooks not found in README.md Provider Skills table
- {provider} not found in providers.yaml
- {provider}-webhooks not registered in .claude-plugin/marketplace.json
```

We hit this on 15 consecutive generated PRs today (#71–#85) before patching the branches by hand.

## Change

Stage the three integration files alongside the skill directory in both commit paths (`lib/generator.ts` generate flow, `index.ts` review flow). `git add` is a no-op for unmodified paths, so this is safe when the AI didn't touch them.

## Testing

- `npx tsc --noEmit` passes.
- Dry run now reports: `Would add files: skills/faketest-webhooks, README.md, providers.yaml, .claude-plugin/marketplace.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)