### PR TITLE
docs(clio): verify signature encoding, regional hosts and handshake against a live account

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -387,8 +387,23 @@ providers:
       meta.webhook_id); models are activity, bill, calendar_entry,
       clio_payments_payment, communication, contact, document, folder, matter,
       task. IMPORTANT: webhooks EXPIRE — 3 days by default, max 31 days via
-      expires_at; renew before expiry. HTTPS-only URLs. Regional base URLs
-      (app.clio.com, eu/au/ca variants).
+      expires_at; renew before expiry. HTTPS-only URLs.
+      *** VERIFIED against a live EU delivery (Jul 2026): X-Hook-Signature is
+      lowercase hex, 64 chars — confirmed by recomputing HMAC-SHA256 over the raw
+      body with the webhook's shared_secret and matching the header exactly. Clio's
+      docs never state the encoding, so handlers may accept base64 as a safety net,
+      but hex is what real deliveries use. ***
+      *** REGIONAL HOSTS ARE MANDATORY: an app exists only in its registration
+      region, and calling /oauth/token on the wrong host returns invalid_client,
+      which masquerades as a bad client secret and sends you hunting in the wrong
+      place. An app created at eu.developers.clio.com must use eu.app.clio.com for
+      OAuth AND API; likewise ca./au. ***
+      *** HANDSHAKE MAY AUTO-COMPLETE: the docs say a webhook stays disabled until
+      the X-Hook-Secret handshake succeeds, but an EU test saw it flip pending ->
+      enabled within ~90s and begin delivering with no handshake request ever
+      arriving. Implement the echo (it is the documented path and how you receive
+      the secret) but do not block on it; shared_secret can also be read back via
+      GET /api/v4/webhooks/:id.json?fields=shared_secret. ***
     testScenario:
       events:
         - created

--- a/skills/clio-webhooks/SKILL.md
+++ b/skills/clio-webhooks/SKILL.md
@@ -30,8 +30,11 @@ Clio Manage delivers webhooks in two distinct kinds of POST request to your URL:
 1. **Handshake** — Immediately after a webhook is created (or its URL changes),
    Clio sends a POST containing an `X-Hook-Secret` header with a freshly
    generated **shared secret**. Your endpoint must confirm it (echo the same
-   header back with `200 OK`). **The webhook is not enabled until the handshake
-   succeeds.** Store that secret — it is the key for verifying every later event.
+   header back with `200 OK`). **Clio's docs say the webhook is not enabled until the handshake
+   succeeds** — though in one observed EU test the webhook auto-enabled and began
+   delivering without any handshake request arriving (see
+   [references/setup.md](references/setup.md)). Implement the echo regardless: it is
+   how you obtain the secret, and it is the key for verifying every later event.
 2. **Events** — Every subsequent delivery is signed. Clio computes
    `HMAC-SHA256(shared_secret, raw_request_body)` and puts the digest in the
    `X-Hook-Signature` header. Verify it against the **raw** body.
@@ -48,9 +51,13 @@ timing-safe.
 
 Clio's docs state only that it "will compute an HMAC-SHA256 signature based on
 the shared secret and the request body" — they never say whether the digest is
-**hex** or **base64** encoded. The handlers below compute the digest once and
-compare against both encodings. **Confirm which one your real deliveries use**
-(log the header once) and you can drop the other.
+hex or base64 encoded.
+
+**Verified against a live delivery: it is lowercase hex** (64 characters). This
+was confirmed by recomputing HMAC-SHA256 over the raw body with the webhook's
+`shared_secret` and matching the header exactly. The handlers below still compute
+the digest once and accept either encoding, so they keep working if Clio ever
+differs by region or changes it — but hex is what you should expect.
 
 Node:
 
@@ -131,7 +138,7 @@ Example event payload:
 
 | Header | Description |
 |--------|-------------|
-| `X-Hook-Signature` | HMAC-SHA256 digest of the raw body (verify this); Clio's docs do not specify hex vs base64 — accept either |
+| `X-Hook-Signature` | HMAC-SHA256 digest of the raw body (verify this). Observed as lowercase hex; the examples accept base64 too as a safety net |
 | `X-Hook-Secret` | Shared secret sent during the handshake; echo it back to activate |
 
 ## Environment Variables

--- a/skills/clio-webhooks/references/setup.md
+++ b/skills/clio-webhooks/references/setup.md
@@ -23,6 +23,13 @@ Use the base URL for the account's region:
 
 Examples below use `app.clio.com`.
 
+> **Get this right first — the failure is misleading.** A Clio app exists only in
+> the region it was registered in. Calling `/oauth/token` on the wrong host returns
+> `invalid_client` ("the client failed to authenticate"), which reads like a wrong
+> client secret and sends you hunting in the wrong place. If your app was created at
+> `eu.developers.clio.com`, every OAuth **and** API call must use `eu.app.clio.com`.
+> Tokens issued in one region are not valid against another.
+
 ## Step 1: Create the Webhook
 
 `POST /api/v4/webhooks.json` with a `data` object. Required fields: `url`,
@@ -52,8 +59,16 @@ curl -X POST https://app.clio.com/api/v4/webhooks.json \
 
 Immediately after creation (and whenever the `url` changes), Clio POSTs your
 endpoint with an `X-Hook-Secret` header containing a generated **shared secret**.
-**The webhook stays disabled until you confirm this handshake.** There are two
-ways to confirm:
+**Clio's docs state the webhook stays disabled until you confirm this handshake.**
+There are two ways to confirm:
+
+> **Observed deviation.** In an EU test (July 2026) a newly created webhook moved
+> from `pending` to `enabled` on its own within ~90 seconds and began delivering
+> events, without any `X-Hook-Secret` request ever reaching the endpoint. Do not
+> block your integration on receiving a handshake you may never get — but do
+> implement the echo, since it is the documented path and the only way Clio hands
+> you the secret in that flow. You can also read `shared_secret` back from
+> `GET /api/v4/webhooks/:id.json?fields=shared_secret`.
 
 ### Option 1 — Immediate (recommended)
 


### PR DESCRIPTION
## Summary

Ran the `clio-webhooks` integration end to end against a real Clio EU account (OAuth → webhook creation → live delivery) and folded what it showed back into the skill and `providers.yaml`.

## Verified

**Signature encoding is lowercase hex.** Previously the skill said Clio's docs don't specify hex vs base64 and accepted either. It's now confirmed — recomputing `HMAC-SHA256(shared_secret, raw_body)` reproduced the header exactly:

```
header   : 13d5a80aeed98742ea00489adeb3c206303635c6d7b311526b7d30396e4fb0fd
computed : 13d5a80aeed98742ea00489adeb3c206303635c6d7b311526b7d30396e4fb0fd  ✓ hex
base64   : E9WoCu7Zh0LqAEia3rPCBjA2NcbXsxFSa30wOW5PsP0=                      ✗
```

The handlers still accept either encoding as a safety net, but hex is now documented as what real deliveries use.

## Two new gotchas worth documenting

**Regional hosts are mandatory, and the failure misleads.** A Clio app exists only in the region it was registered in. Calling `/oauth/token` on the wrong host returns `invalid_client` — "the client failed to authenticate" — which reads like a wrong client secret. An app created at `eu.developers.clio.com` must use `eu.app.clio.com` for OAuth *and* API.

**The handshake may auto-complete.** The docs say a webhook stays disabled until the `X-Hook-Secret` handshake succeeds. In this test the webhook moved `pending` → `enabled` within ~90 seconds and started delivering, with no handshake request ever reaching the endpoint. The echo is still worth implementing (it's the documented path and how you receive the secret), but integrations shouldn't block on it — `shared_secret` can also be read back via `GET /api/v4/webhooks/:id.json?fields=shared_secret`.

## Also confirmed correct (no change needed)

- Clio **generates** `shared_secret` and returns it — you don't supply it
- Default expiry is 3 days (`created_at` 24 Jul → `expires_at` 27 Jul)
- Payload is `{data, meta}` with the bare action at `meta.event` (`created`, not `contact.created`)

## Scope

Docs only — `SKILL.md`, `references/setup.md`, and the `providers.yaml` brief. No example code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)