### PR TITLE
fix(exact-online): verify HashCode scheme live, acknowledge the callback validation POST

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -607,6 +607,20 @@ providers:
       only Topic, Action (Create/Update/Delete), Key (entity GUID), Division, ClientId — so
       call the REST API to fetch the full record. Return 2xx quickly; Exact retries failures.
       GoodsDeliveries supports near-instant delivery via the IsInstant flag. No official SDK.
+      *** SIGNING SCHEME VERIFIED (Jul 2026, live Accounts/Update delivery): HMAC-SHA256 over
+      the raw substring between {"Content": and ,"HashCode":, hex, UPPERCASED, reproduced the
+      delivered HashCode exactly. Lowercase hex and base64 both failed, so uppercasing is
+      required. Caveat: Exact sends compact JSON, so raw-substring and re-serialized-compact
+      forms were byte-identical for that delivery and both matched — keep the raw substring,
+      it is the only form that survives whitespace or key reordering. ***
+      *** CALLBACK VALIDATION: ~1s after the subscription is created Exact sends an EMPTY POST
+      (content-length: 0) to the callback. Handlers MUST acknowledge it with 2xx rather than
+      running verification and 401ing, or the subscription can be left unvalidated. ***
+      *** DELIVERY IS BATCHED: subscriptions default to IsInstant false and a change observed
+      with EventCreatedOn 17:20:55 arrived several minutes later. Drive freshness logic off
+      Content.EventCreatedOn, not receipt time. ***
+      Content also carries ExactOnlineEndpoint (a ready-made API URL for the changed record —
+      use it instead of hand-building the fetch URL) and EventCreatedOn.
       Confirmed topics: Accounts, Items, StockPositions, FinancialTransactions,
       GoodsDeliveries, Contacts (docs list ~30 topics).
     testScenario:

--- a/skills/exact-online-webhooks/SKILL.md
+++ b/skills/exact-online-webhooks/SKILL.md
@@ -70,12 +70,20 @@ included). Key it with your app's **Webhook secret** (from the Exact App Center)
 hex-encode, **uppercase**, and compare to `HashCode`. Do **not** re-serialize the
 parsed `Content` object — key order/whitespace would differ and break the hash.
 
-> **Verify this against a real delivery before relying on it.** Exact's KB pages
-> are JS-rendered and don't state the signed substring in prose; the exact
-> boundaries used here match well-established community implementations (e.g.
-> picqer's PHP client) rather than a quotable official spec. Log the raw body on
-> your first deliveries and confirm the digest matches — see
-> [references/verification.md](references/verification.md) for the failure modes.
+> **Verified against a real delivery (July 2026).** An `Accounts/Update` webhook
+> was reproduced exactly: HMAC-SHA256 over the raw substring between `{"Content":`
+> and `,"HashCode":`, hex-encoded and uppercased, matched the delivered `HashCode`.
+> Lowercase hex and base64 both failed, so the uppercasing is required.
+>
+> Exact's KB pages are JS-rendered and never state the signed substring in prose —
+> these boundaries originally came from community implementations (picqer's PHP
+> client) and are now confirmed by evidence.
+>
+> One caveat: Exact sends **compact JSON**, so for that delivery the raw substring
+> and a re-serialized compact `Content` were byte-identical and both matched. The
+> test therefore cannot distinguish them. Keep using the raw substring — it is the
+> only form that stays correct if Exact ever emits whitespace or reorders keys.
+> See [references/verification.md](references/verification.md) for the failure modes.
 
 ```javascript
 const crypto = require('crypto');

--- a/skills/exact-online-webhooks/examples/express/src/index.js
+++ b/skills/exact-online-webhooks/examples/express/src/index.js
@@ -72,6 +72,15 @@ app.post(
   '/webhooks/exact-online',
   express.raw({ type: '*/*' }),
   async (req, res) => {
+    // Exact validates the callback URL when the subscription is created by
+    // sending an EMPTY POST (content-length: 0). There is no Content to hash,
+    // so acknowledge it instead of failing verification — returning 401 here
+    // can leave the subscription unvalidated.
+    if (!req.body || req.body.length === 0) {
+      console.log('Empty POST — Exact callback validation, acknowledging');
+      return res.status(200).send('OK');
+    }
+
     // Verify before parsing.
     if (!verifyExactWebhook(req.body, process.env.EXACT_WEBHOOK_SECRET)) {
       console.error('Webhook signature verification failed');

--- a/skills/exact-online-webhooks/examples/express/test/webhook.test.js
+++ b/skills/exact-online-webhooks/examples/express/test/webhook.test.js
@@ -109,6 +109,19 @@ describe('POST /webhooks/exact-online', () => {
   });
 });
 
+describe('Exact callback validation (empty POST)', () => {
+  test('acknowledges an empty body with 200 instead of 401', async () => {
+    // Exact validates the callback URL on subscription creation by POSTing an
+    // empty body. Rejecting it can leave the subscription unvalidated.
+    const res = await request(app)
+      .post('/webhooks/exact-online')
+      .set('Content-Type', 'application/json')
+      .send('');
+
+    expect(res.status).toBe(200);
+  });
+});
+
 describe('GET /health', () => {
   test('returns ok', async () => {
     const res = await request(app).get('/health');

--- a/skills/exact-online-webhooks/examples/fastapi/main.py
+++ b/skills/exact-online-webhooks/examples/fastapi/main.py
@@ -61,6 +61,14 @@ async def exact_webhook(request: Request):
     # Read the raw body — required for signature verification.
     raw_body = await request.body()
 
+    # Exact validates the callback URL when the subscription is created by
+    # sending an EMPTY POST (content-length: 0). There is no Content to hash,
+    # so acknowledge it instead of failing verification — returning 401 here
+    # can leave the subscription unvalidated.
+    if not raw_body:
+        print("Empty POST — Exact callback validation, acknowledging")
+        return {"status": "ok"}
+
     # Verify before parsing.
     if not verify_exact_webhook(raw_body, exact_secret):
         raise HTTPException(status_code=401, detail="Invalid signature")

--- a/skills/exact-online-webhooks/examples/fastapi/test_webhook.py
+++ b/skills/exact-online-webhooks/examples/fastapi/test_webhook.py
@@ -117,3 +117,13 @@ class TestHealth:
         response = client.get("/health")
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
+
+def test_empty_post_is_acknowledged():
+    """Exact validates the callback URL on subscription creation with an empty
+    POST. Rejecting it can leave the subscription unvalidated."""
+    response = client.post(
+        "/webhooks/exact-online",
+        content=b"",
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200

--- a/skills/exact-online-webhooks/examples/nextjs/app/webhooks/exact-online/route.ts
+++ b/skills/exact-online-webhooks/examples/nextjs/app/webhooks/exact-online/route.ts
@@ -62,6 +62,15 @@ export async function POST(request: NextRequest) {
   // Read the raw body — required for signature verification.
   const rawBody = await request.text();
 
+  // Exact validates the callback URL when the subscription is created by
+  // sending an EMPTY POST (content-length: 0). There is no Content to hash,
+  // so acknowledge it instead of failing verification — returning 401 here
+  // can leave the subscription unvalidated.
+  if (!rawBody) {
+    console.log('Empty POST — Exact callback validation, acknowledging');
+    return NextResponse.json({ status: 'ok' }, { status: 200 });
+  }
+
   // Verify before parsing.
   if (!verifyExactWebhook(rawBody, process.env.EXACT_WEBHOOK_SECRET!)) {
     console.error('Webhook signature verification failed');

--- a/skills/exact-online-webhooks/examples/nextjs/test/webhook.test.ts
+++ b/skills/exact-online-webhooks/examples/nextjs/test/webhook.test.ts
@@ -108,3 +108,14 @@ describe('POST /webhooks/exact-online', () => {
     expect(res.status).toBe(200);
   });
 });
+
+describe('Exact callback validation (empty POST)', () => {
+  it('acknowledges an empty body with 200 instead of 401', async () => {
+    // Exact validates the callback URL on subscription creation by POSTing an
+    // empty body. Rejecting it can leave the subscription unvalidated.
+    const { POST } = await routeModulePromise;
+    const res = await POST(makeRequest('') as never);
+    expect(res.status).toBe(200);
+  });
+});
+

--- a/skills/exact-online-webhooks/references/overview.md
+++ b/skills/exact-online-webhooks/references/overview.md
@@ -24,10 +24,12 @@ Every delivery has the same envelope:
 {
   "Content": {
     "Topic": "Accounts",
+    "ClientId": "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+    "Division": 123456,
     "Action": "Update",
     "Key": "d4d4c8b6-1a2b-4c3d-9e8f-1234567890ab",
-    "Division": 123456,
-    "ClientId": "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d"
+    "ExactOnlineEndpoint": "https://start.exactonline.co.uk/api/v1/123456/crm/Accounts(guid'd4d4c8b6-1a2b-4c3d-9e8f-1234567890ab')",
+    "EventCreatedOn": "2026-07-24T17:20:55.543"
   },
   "HashCode": "5A3F9C2E7B1D8A46F0C3E9B2D7A15C8E4F6091A2B3C4D5E6F7089ABCDEF01234"
 }
@@ -40,10 +42,27 @@ Every delivery has the same envelope:
 | `Content.Key` | GUID of the changed entity — use it to fetch the full record |
 | `Content.Division` | The division (company) the change belongs to |
 | `Content.ClientId` | Your app's client id |
+| `Content.ExactOnlineEndpoint` | Ready-made API URL for the changed record — use this instead of hand-building the fetch URL |
+| `Content.EventCreatedOn` | When the change occurred (note this can be minutes before delivery — see below) |
 | `HashCode` | Uppercase hex HMAC-SHA256 of the raw `Content` JSON (the signature) |
 
 `GoodsDeliveries` deliveries can additionally arrive near-instantly when the
 subscription is created with the `IsInstant` flag.
+
+## Delivery Behaviour (observed)
+
+- **Subscriptions default to `IsInstant: false` and deliveries are batched.** In a
+  July 2026 test an `Accounts` change with `EventCreatedOn` 17:20:55 arrived a few
+  minutes later — do not expect real-time delivery, and drive any freshness logic
+  off `EventCreatedOn` rather than receipt time.
+- **The callback URL is validated on subscription creation.** Roughly a second
+  after `POST .../webhooks/WebhookSubscriptions` returns, Exact sends an **empty
+  POST** (`content-length: 0`) to the callback. Your handler must tolerate an empty
+  body rather than erroring — verification should be skipped for it, since there is
+  no `Content` to hash.
+- Deliveries carry no signature header; `HashCode` inside the body is the only
+  signature. Other headers seen in practice are Azure-style tracing fields
+  (`request-id`, `request-context`), which are not part of any contract.
 
 ## Common Topics
 


### PR DESCRIPTION
## Summary

Exercised `exact-online-webhooks` against a real Exact Online UK account (OAuth → subscription → live delivery). This confirms the trickiest signing scheme in batch 5 and fixes a bug that could leave subscriptions unvalidated.

## Signing scheme — confirmed

The scheme was previously hedged because it came from picqer's PHP client rather than Exact's own docs (their KB pages are JS-rendered and never state the signed substring). A live `Accounts/Update` delivery reproduces it exactly:

```
HMAC-SHA256( raw substring between {"Content": and ,"HashCode": , secret ) → UPPERCASE hex
= D82445D5B39940EF2A54EC63FE44E5CB6A92276B70A80D3B503D892AD4FC89FA  ✓
```

Lowercase hex and base64 both failed, so the uppercasing is genuinely required.

*Honest caveat, kept in the docs:* Exact sends compact JSON, so for that delivery the raw substring and a re-serialized compact `Content` were byte-identical and both matched. The test cannot discriminate them. Raw substring remains the guidance — it is the only form that stays correct if Exact ever emits whitespace or reorders keys.

## Bug fixed: the callback validation POST was being rejected

Roughly one second after `POST .../webhooks/WebhookSubscriptions` returns, Exact sends an **empty POST** (`content-length: 0`) to the callback URL to validate it. The examples ran signature verification on it, failed (there is no `Content` to hash), and returned **401** — which can leave the subscription unvalidated.

All three handlers now acknowledge an empty body with 2xx before verifying, with a test each.

## Also documented from the same run

- **Delivery is batched.** Subscriptions default to `IsInstant: false`; a change with `EventCreatedOn` 17:20:55 arrived several minutes later. Freshness logic should key off `EventCreatedOn`, not receipt time.
- **`Content.ExactOnlineEndpoint`** — a ready-made API URL for the changed record, so you don't hand-build the fetch URL. Previously undocumented here.
- **`Content.EventCreatedOn`** — likewise undocumented.
- Deliveries carry **no signature header**; `HashCode` in the body is the only signature, as the skill already said.

## Testing

- Express (jest): **12 passed**
- Next.js (vitest): **15 passed**
- FastAPI (pytest): **16 passed**

Each suite gained an empty-POST acknowledgement case. `./scripts/validate-provider.sh exact-online-webhooks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)