### PR TITLE
fix(gocardless): apply firsthand verification findings (signature, retry, docs domain, event)

### DIFF
--- a/skills/gocardless-webhooks/SKILL.md
+++ b/skills/gocardless-webhooks/SKILL.md
@@ -27,14 +27,21 @@ HMAC-SHA256 signature in the `Webhook-Signature` header.
 
 ## How GoCardless Signs Webhooks
 
-- **Header:** `Webhook-Signature`
+- **Header:** `Webhook-Signature` — a bare 64-char lowercase hex digest (no `X-`
+  prefix, no `sha256=` scheme prefix)
 - **Algorithm:** HMAC-SHA256 over the **raw request body**, keyed with the
   webhook endpoint secret (from your GoCardless Dashboard)
+- **Key:** use the secret **verbatim as a UTF-8 string** — do NOT base64-decode it
+  even though it looks base64url-ish; decoding it produces a wrong signature
 - **Encoding:** lowercase **hex** string
 - **Comparison:** timing-safe equality
-- **Response:** return `204 No Content` once the whole batch is accepted. Return a
-  non-2xx (e.g. `498`) if verification fails. GoCardless **retries the whole batch**
-  on any non-2xx, so event handlers must be **idempotent on `event.id`**.
+- **Response:** return `204 No Content` once the whole batch is accepted; a non-2xx
+  (e.g. `498`) marks the delivery failed. GoCardless does **not** auto-retry —
+  redelivery is manual (`POST /webhooks/{id}/actions/retry`). Delivery is
+  at-least-once, so keep handlers **idempotent on `event.id`**.
+
+*(Scheme verified 2026-08 against a live sandbox delivery and the official
+`gocardless-nodejs` SDK; GoCardless's prose still doesn't name the algorithm.)*
 
 Always verify against the **raw body** — parsing JSON first and re-serializing will
 change the bytes and break the signature.
@@ -86,6 +93,7 @@ GoCardless events combine a `resource_type` with an `action`. The most common:
 | `payments` | `cancelled` | Payment cancelled before submission |
 | `payments` | `charged_back` | Customer charged the payment back |
 | `mandates` | `active` | Mandate set up and ready to collect |
+| `mandates` | `customer_approval_granted` | Customer authorised the mandate (confirmed live) |
 | `mandates` | `cancelled` | Mandate cancelled (e.g. bank account closed) |
 | `mandates` | `failed` | Mandate setup failed |
 | `mandates` | `expired` | Mandate expired through inactivity |
@@ -129,7 +137,7 @@ local tunnel + web UI for inspecting requests. Use port `8000` for the FastAPI e
 
 ## Recommended: webhook-handler-patterns
 
-We recommend installing the [webhook-handler-patterns](https://github.com/hookdeck/webhook-skills/tree/main/skills/webhook-handler-patterns) skill alongside this one. GoCardless retries the whole batch on any non-2xx, so idempotency matters. Key references (open on GitHub):
+We recommend installing the [webhook-handler-patterns](https://github.com/hookdeck/webhook-skills/tree/main/skills/webhook-handler-patterns) skill alongside this one. GoCardless doesn't auto-retry (redelivery is manual), but delivery is at-least-once, so idempotency matters. Key references (open on GitHub):
 
 - [Handler sequence](https://github.com/hookdeck/webhook-skills/blob/main/skills/webhook-handler-patterns/references/handler-sequence.md) — Verify first, parse second, handle idempotently third
 - [Idempotency](https://github.com/hookdeck/webhook-skills/blob/main/skills/webhook-handler-patterns/references/idempotency.md) — Prevent duplicate processing (dedupe on `event.id`)

--- a/skills/gocardless-webhooks/TODO.md
+++ b/skills/gocardless-webhooks/TODO.md
@@ -15,5 +15,5 @@ Contributions to address these items are welcome.
 ## Suggestions
 
 - [ ] Everything else is accurate and internally consistent — signature verification (SDK + manual), event names, files, dependency versions, env vars, endpoint path, and tests all check out.
-- [ ] The 498 'Invalid Token' status is non-standard HTTP but is genuinely what GoCardless's own docs use, so it is correct to keep; a one-line note in verification.md explaining 'any non-2xx triggers a retry' already covers readers who find 498 surprising.
+- [ ] The 498 'Invalid Token' status is non-standard HTTP but is genuinely what GoCardless's own docs use, so it is correct to keep. (Note: the earlier 'any non-2xx triggers a retry' framing was corrected in 2026-08 — GoCardless does not auto-retry; redelivery is manual via POST /webhooks/{id}/actions/retry.)
 

--- a/skills/gocardless-webhooks/examples/express/README.md
+++ b/skills/gocardless-webhooks/examples/express/README.md
@@ -47,7 +47,7 @@ Server runs on http://localhost:3000 and accepts webhooks at
   It throws `InvalidSignatureError` if the signature doesn't match.
 - A webhook is a **batch** of up to 250 events. Each event is dispatched by
   `resource_type` + `action`. Return `204 No Content` to acknowledge the batch.
-- GoCardless retries the whole batch on any non-2xx, so keep handlers **idempotent on
+- Delivery is at-least-once and manual retries replay the whole batch, so keep handlers **idempotent on
   `event.id`**.
 
 ## Test

--- a/skills/gocardless-webhooks/examples/express/src/index.js
+++ b/skills/gocardless-webhooks/examples/express/src/index.js
@@ -40,7 +40,7 @@ app.post(
     }
 
     // A single webhook is a BATCH of events (up to 250). Process each one.
-    // GoCardless retries the whole batch on any non-2xx, so handlers must be
+    // Delivery is at-least-once and a manual retry replays the whole batch, so handlers must be
     // idempotent on event.id.
     for (const event of events) {
       handleEvent(event);

--- a/skills/gocardless-webhooks/examples/express/test/webhook.test.js
+++ b/skills/gocardless-webhooks/examples/express/test/webhook.test.js
@@ -118,6 +118,18 @@ describe('POST /webhooks/gocardless', () => {
   });
 });
 
+describe("GoCardless official public test vector", () => {
+  // From gocardless-nodejs (src/fixtures/webhook_body.json), minified. Ties this
+  // skill's signing to GoCardless's own published fixture. Reproduced 2026-08.
+  const VECTOR_SECRET = 'ED7D658C-D8EB-4941-948B-3973214F2D49';
+  const VECTOR_BODY = '{"events":[{"id":"EV00BD05S5VM2T","created_at":"2018-07-05T09:13:51.404Z","resource_type":"subscriptions","action":"created","links":{"subscription":"SB0003JJQ2MR06"},"details":{"origin":"api","cause":"subscription_created","description":"Subscription created via the API."},"metadata":{}},{"id":"EV00BD05TB8K63","created_at":"2018-07-05T09:13:56.893Z","resource_type":"mandates","action":"created","links":{"mandate":"MD000AMA19XGEC"},"details":{"origin":"api","cause":"mandate_created","description":"Mandate created via the API."},"metadata":{}}]}';
+  const VECTOR_SIG = '2693754819d3e32d7e8fcb13c729631f316c6de8dc1cf634d6527f1c07276e7e';
+
+  it("reproduces the published signature exactly", () => {
+    expect(sign(VECTOR_BODY, VECTOR_SECRET)).toBe(VECTOR_SIG);
+  });
+});
+
 describe('GET /health', () => {
   it('returns health status', async () => {
     const response = await request(app).get('/health');

--- a/skills/gocardless-webhooks/examples/fastapi/README.md
+++ b/skills/gocardless-webhooks/examples/fastapi/README.md
@@ -49,7 +49,7 @@ The webhook route is available at `POST http://localhost:8000/webhooks/gocardles
   to the `Webhook-Signature` header with `hmac.compare_digest` (timing-safe).
 - A webhook is a **batch** of up to 250 events, each dispatched by `resource_type` +
   `action`. Return `204 No Content` to acknowledge; keep handlers **idempotent on
-  `event["id"]`** because GoCardless retries the whole batch on any non-2xx.
+  `event["id"]`** because delivery is at-least-once and manual retries replay the whole batch.
 
 ## Test
 

--- a/skills/gocardless-webhooks/examples/fastapi/main.py
+++ b/skills/gocardless-webhooks/examples/fastapi/main.py
@@ -47,7 +47,7 @@ async def handle_webhook(request: Request):
     payload = json.loads(raw_body)
     events = payload.get("events", [])
 
-    # A webhook is a BATCH of events (up to 250). GoCardless retries the whole batch
+    # A webhook is a BATCH of events (up to 250). Delivery is at-least-once and a manual retry replays the whole batch
     # on any non-2xx, so handlers must be idempotent on event["id"].
     for event in events:
         handle_event(event)

--- a/skills/gocardless-webhooks/examples/fastapi/test_webhook.py
+++ b/skills/gocardless-webhooks/examples/fastapi/test_webhook.py
@@ -105,3 +105,14 @@ def test_health():
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}
+
+
+def test_gocardless_official_public_test_vector():
+    """From gocardless-nodejs (src/fixtures/webhook_body.json), minified. Ties
+    this skill's signing to GoCardless's own published fixture (reproduced 2026-08)."""
+    import hmac as _hmac, hashlib as _hashlib
+    secret = "ED7D658C-D8EB-4941-948B-3973214F2D49"
+    body = "{\"events\":[{\"id\":\"EV00BD05S5VM2T\",\"created_at\":\"2018-07-05T09:13:51.404Z\",\"resource_type\":\"subscriptions\",\"action\":\"created\",\"links\":{\"subscription\":\"SB0003JJQ2MR06\"},\"details\":{\"origin\":\"api\",\"cause\":\"subscription_created\",\"description\":\"Subscription created via the API.\"},\"metadata\":{}},{\"id\":\"EV00BD05TB8K63\",\"created_at\":\"2018-07-05T09:13:56.893Z\",\"resource_type\":\"mandates\",\"action\":\"created\",\"links\":{\"mandate\":\"MD000AMA19XGEC\"},\"details\":{\"origin\":\"api\",\"cause\":\"mandate_created\",\"description\":\"Mandate created via the API.\"},\"metadata\":{}}]}"
+    expected = "2693754819d3e32d7e8fcb13c729631f316c6de8dc1cf634d6527f1c07276e7e"
+    computed = _hmac.new(secret.encode("utf-8"), body.encode("utf-8"), _hashlib.sha256).hexdigest()
+    assert computed == expected

--- a/skills/gocardless-webhooks/examples/nextjs/README.md
+++ b/skills/gocardless-webhooks/examples/nextjs/README.md
@@ -48,7 +48,7 @@ The webhook route is available at `POST http://localhost:3000/webhooks/gocardles
   throwing `InvalidSignatureError` on mismatch.
 - A webhook is a **batch** of up to 250 events, each dispatched by `resource_type` +
   `action`. Return `204 No Content` to acknowledge; keep handlers **idempotent on
-  `event.id`** because GoCardless retries the whole batch on any non-2xx.
+  `event.id`** because delivery is at-least-once and manual retries replay the whole batch.
 
 ## Test
 

--- a/skills/gocardless-webhooks/examples/nextjs/app/webhooks/gocardless/route.ts
+++ b/skills/gocardless-webhooks/examples/nextjs/app/webhooks/gocardless/route.ts
@@ -41,7 +41,7 @@ export async function POST(request: NextRequest) {
     return new Response('Bad request', { status: 400 });
   }
 
-  // A webhook is a BATCH of events (up to 250). GoCardless retries the whole batch on
+  // A webhook is a BATCH of events (up to 250). Delivery is at-least-once and a manual retry replays the whole batch;
   // any non-2xx, so handlers must be idempotent on event.id.
   for (const event of events) {
     handleEvent(event);

--- a/skills/gocardless-webhooks/examples/nextjs/test/webhook.test.ts
+++ b/skills/gocardless-webhooks/examples/nextjs/test/webhook.test.ts
@@ -102,3 +102,18 @@ describe('POST /webhooks/gocardless', () => {
     expect(response.status).toBe(498);
   });
 });
+
+
+describe('GoCardless official public test vector', () => {
+  // From gocardless-nodejs (src/fixtures/webhook_body.json), minified. Ties this
+  // skill's signing to GoCardless's own published fixture. Reproduced 2026-08.
+  it('reproduces the published signature exactly', () => {
+    const crypto = require('crypto');
+    const secret = 'ED7D658C-D8EB-4941-948B-3973214F2D49';
+    const body = '{"events":[{"id":"EV00BD05S5VM2T","created_at":"2018-07-05T09:13:51.404Z","resource_type":"subscriptions","action":"created","links":{"subscription":"SB0003JJQ2MR06"},"details":{"origin":"api","cause":"subscription_created","description":"Subscription created via the API."},"metadata":{}},{"id":"EV00BD05TB8K63","created_at":"2018-07-05T09:13:56.893Z","resource_type":"mandates","action":"created","links":{"mandate":"MD000AMA19XGEC"},"details":{"origin":"api","cause":"mandate_created","description":"Mandate created via the API."},"metadata":{}}]}';
+    const expected = '2693754819d3e32d7e8fcb13c729631f316c6de8dc1cf634d6527f1c07276e7e';
+    const computed = crypto.createHmac('sha256', secret).update(body).digest('hex');
+    expect(computed).toBe(expected);
+  });
+});
+

--- a/skills/gocardless-webhooks/references/overview.md
+++ b/skills/gocardless-webhooks/references/overview.md
@@ -12,7 +12,7 @@ an `events` array (up to 250 events per request). Each event describes one chang
 one resource. The request is signed with an HMAC-SHA256 signature in the
 `Webhook-Signature` header.
 
-Because GoCardless **retries the entire batch** if your endpoint returns any non-2xx
+Because delivery is at-least-once and a manual retry (GoCardless does not auto-retry) replays the whole batch
 response, your handler must be **idempotent** — dedupe on each `event.id` so replays
 don't double-process.
 
@@ -38,9 +38,18 @@ don't double-process.
         "reason_code": "ADDACS-B"
       }
     }
-  ]
+  ],
+  "meta": { "webhook_id": "WB0123..." }
 }
 ```
+
+> **Confirmed against a live sandbox delivery (2026-08).** Real deliveries carry
+> a top-level `meta.webhook_id` alongside `events` (the SDK's `parseWithMeta`
+> reads it). `resource_type` is **plural on the wire** — e.g. an observed
+> delivery had `"resource_type":"billing_requests"`, `"action":"select_institution"`,
+> with `details{origin,cause,description}` and `links{customer,billing_request}`.
+> Observed request headers: `origin: https://api-sandbox.gocardless.com`,
+> `user-agent: gocardless-webhook-service/1.2`, `content-type: application/json`.
 
 Key fields on each event:
 
@@ -119,5 +128,5 @@ You typically dispatch on the combination of `resource_type` + `action`.
 ## Full Event Reference
 
 For the complete list of resource types and actions, see GoCardless's
-[webhook documentation](https://developer.gocardless.com/api-reference/#appendix-webhooks)
-and [staying up to date with webhooks](https://developer.gocardless.com/getting-started/api/staying-up-to-date-with-webhooks/).
+[webhook documentation](https://docs.gocardless.com/api-reference/#appendix-webhooks)
+and [staying up to date with webhooks](https://docs.gocardless.com/getting-started/api/staying-up-to-date-with-webhooks/).

--- a/skills/gocardless-webhooks/references/setup.md
+++ b/skills/gocardless-webhooks/references/setup.md
@@ -44,11 +44,14 @@ Each environment has its own webhook endpoints and secrets. Configure the correc
 ## Retries and Delivery
 
 - GoCardless expects a **2xx** response (return `204 No Content`).
-- If your endpoint returns a non-2xx status, times out, or is unreachable,
-  GoCardless **retries the entire batch** with exponential backoff.
-- Because the whole batch is retried, make handlers **idempotent on `event.id`**.
-- You can view delivery attempts and manually retry from the Dashboard under the
-  webhook endpoint.
+- **GoCardless does NOT automatically retry failed deliveries.** There is no
+  exponential-backoff schedule. If your endpoint returns a non-2xx, times out, or
+  is unreachable, the delivery is simply marked failed.
+- **Redelivery is manual**, either from the Dashboard (webhook endpoint → the
+  failed delivery) or via the API: `POST /webhooks/{id}/actions/retry` (the
+  `gocardless-nodejs` SDK exposes this as `webhooks.retry(id)`).
+- Delivery is at-least-once and manual retries replay the whole batch, so keep
+  handlers **idempotent on `event.id`**.
 
 ## Testing Locally
 

--- a/skills/gocardless-webhooks/references/verification.md
+++ b/skills/gocardless-webhooks/references/verification.md
@@ -28,6 +28,14 @@ it to the header using a **timing-safe** equality check.
 | Secret | Webhook endpoint secret from the Dashboard |
 | Comparison | Timing-safe (`crypto.timingSafeEqual` / `hmac.compare_digest`) |
 
+> **Verified against a live sandbox delivery and GoCardless's official SDK
+> (2026-08).** A real delivery's `Webhook-Signature` was reproduced exactly by
+> `HMAC-SHA256(rawBody, secret)` over the exact wire bytes, and it matches the
+> `gocardless-nodejs` SDK's own construction
+> (`crypto.createHmac('sha256', secret).update(body).digest()` +
+> `timingSafeEqual`). GoCardless's prose still never names the algorithm — so
+> the algorithm is confirmed by evidence, not by their docs.
+
 ## Implementation
 
 ### SDK Verification (Node.js — preferred)
@@ -89,24 +97,34 @@ def verify(raw_body: bytes, signature_header: str, secret: str) -> bool:
 - **Header name casing.** The header is `Webhook-Signature`. HTTP headers are
   case-insensitive; most frameworks lower-case them (`webhook-signature`).
 - **Hex, not base64.** The signature is hex-encoded. Don't base64-decode it.
+- **Use the secret verbatim — do NOT base64-decode the KEY.** The endpoint secret
+  looks base64url-ish (e.g. contains `-` and `_`), which tempts a base64 decode
+  before HMAC-ing. Don't: the key is the raw UTF-8 string. Base64-decoding it
+  produces a non-matching signature (verified — decoding the public test vector's
+  secret yields the wrong digest).
+- **Header format.** `Webhook-Signature` carries a bare 64-char lowercase hex
+  digest — no `X-` prefix and no `sha256=` scheme prefix.
 - **Timing-safe compare.** Use `crypto.timingSafeEqual` (Node) or `hmac.compare_digest`
   (Python), not `==`. Guard against length mismatches (they raise/throw) by treating
   any exception as "invalid".
 - **Batches.** The body has an `events` array (up to 250 events). Verify once over the
   whole body, then iterate the events.
-- **Idempotency.** GoCardless retries the whole batch on any non-2xx. Dedupe on
-  `event.id` so retries don't double-process.
+- **Idempotency.** GoCardless does NOT auto-retry (see below), but delivery is
+  at-least-once and you (or a teammate) can manually redeliver, so still dedupe on
+  `event.id` to avoid double-processing.
 
 ## Response Codes
 
 | Situation | Status |
 |-----------|--------|
 | Signature valid, batch accepted | `204 No Content` |
-| Signature invalid or missing | `498` (any non-2xx triggers a retry) |
+| Signature invalid or missing | `498 Invalid Token` (GoCardless's documented value) |
 | Malformed body / unexpected error | `400` / `500` |
 
 GoCardless's documentation uses `204` for success and `498 Invalid Token` for a failed
-signature check. Any non-2xx response causes GoCardless to retry the batch.
+signature check. GoCardless does **not** automatically retry failed deliveries —
+redelivery is manual (see setup.md: `POST /webhooks/{id}/actions/retry` or the
+Dashboard). Still return `204` promptly and process asynchronously.
 
 ## Debugging Verification Failures
 


### PR DESCRIPTION
## Summary

Verified the `gocardless-webhooks` skill end to end against a **live GoCardless sandbox delivery** and the **official `gocardless-nodejs` SDK**, and independently reproduced the SDK's public test vector. Turns confirmed-but-hedged facts into asserted ones, and fixes three stale/incorrect claims.

## Confirmed (now asserted as fact)

- **HMAC-SHA256, hex, over the raw body**, header `Webhook-Signature` (a bare 64-char lowercase hex digest — no `X-` or `sha256=` prefix). Reproduced from a live delivery and matching the SDK's `createHmac('sha256', secret).update(body).digest()` + `timingSafeEqual`. GoCardless's prose still never names the algorithm, so the "docs don't name it" note stays — but the scheme is now confirmed by evidence.
- **The endpoint secret is the HMAC key verbatim (UTF-8 string).** It looks base64url-ish, which tempts a base64 decode — **don't**. Decoding it produces a non-matching signature (verified against the public vector). Added as an explicit gotcha.
- **Envelope** carries a top-level `meta.webhook_id` alongside `events`; `resource_type` is **plural on the wire** (observed `billing_requests`/`select_institution`); documented the observed request headers.

## Corrections

1. **Retry claim was wrong.** The skill said GoCardless "retries the entire batch with exponential backoff." It does **not** auto-retry — redelivery is **manual** via `POST /webhooks/{id}/actions/retry` (the SDK exposes `webhooks.retry(id)` — confirmed in the SDK source) or the Dashboard. Fixed across SKILL.md, both reference docs, all three example sources and their READMEs. (Doc-confirmed; a 500-response end-to-end test would settle it empirically.)
2. **Stale docs domain** `developer.gocardless.com` (deprecates 24 Aug 2026) → `docs.gocardless.com`.
3. **Added the confirmed** `mandates` / `customer_approval_granted` event.

## Test vector (public, reproduced here)

Added a known-answer test to all three suites tying the skill's signing to GoCardless's own published fixture:

```
secret:    ED7D658C-D8EB-4941-948B-3973214F2D49
body:      gocardless-nodejs src/fixtures/webhook_body.json (minified)
signature: 2693754819d3e32d7e8fcb13c729631f316c6de8dc1cf634d6527f1c07276e7e
check:     hex(HMAC_SHA256(secret, body)) === signature   ✓ reproduced
```

(Uses GoCardless's public SDK fixture, not any sandbox secret.)

## Testing

Express **8**, Next.js **7**, FastAPI **8** pass; `validate-provider.sh gocardless-webhooks` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)