### PR TITLE
fix(square): apply firsthand sandbox verification findings (2026-08)

### DIFF
--- a/skills/square-webhooks/SKILL.md
+++ b/skills/square-webhooks/SKILL.md
@@ -25,10 +25,18 @@ metadata:
 ## Verification (core)
 
 Square signs each webhook with an **HMAC-SHA256** over the **notification URL
-concatenated with the raw request body**, base64-encoded, delivered in the
+concatenated with the raw request body** (`notificationUrl + rawBody`, in that
+order — confirmed by testing), base64-encoded, delivered in the
 `x-square-hmacsha256-signature` header. The notification URL is part of the
-signed content, so it must exactly match the URL configured in your Square
-subscription. Always verify the **raw** body — never `JSON.parse` first.
+signed content, so it must exactly match — byte-for-byte — the URL configured in
+your Square subscription. Always verify the **raw** body — never `JSON.parse`
+first.
+
+> **Top pitfall:** the HMAC key is the subscription's **Signature Key** (short,
+> e.g. `qfjakbt2uWB8DKAMECF-EA`), used verbatim — **not** an OAuth access token
+> (`EAAA…`), which produces no match. Square also still sends a deprecated
+> `x-square-signature` (HMAC-SHA1) header alongside the SHA-256 one; verify the
+> **SHA-256** header.
 
 Node (official Square SDK — recommended):
 

--- a/skills/square-webhooks/examples/express/test/webhook.test.js
+++ b/skills/square-webhooks/examples/express/test/webhook.test.js
@@ -51,6 +51,29 @@ describe('verifySquareSignature', () => {
 
     await expect(verifySquareSignature(body, signature)).resolves.toBe(false);
   });
+
+  // Known-answer test: locks the exact signing construction — HMAC-SHA256 over
+  // (notificationUrl + rawBody), base64, key used verbatim. The digest is
+  // self-computed (not a Square-produced signature; the ordering and encoding
+  // were confirmed against a live delivery and the official SDK, 2026-08). This
+  // guards against a regression that flips the order to (body + url) or decodes
+  // the key, which a round-trip test using the same helper could otherwise mask.
+  it('accepts a fixed known-answer signature (URL + body, base64)', async () => {
+    const kaKey = 'test_signature_key';
+    const kaUrl = 'https://example.com/webhooks/square';
+    const kaBody =
+      '{"merchant_id":"6SSW7HV8K2ST5","type":"order.updated",' +
+      '"event_id":"11111111-2222-3333-4444-555555555555",' +
+      '"created_at":"2026-08-04T12:00:00.000Z","data":{"type":"order_updated",' +
+      '"id":"ORDER123","object":{"order_updated":{"order_id":"ORDER123",' +
+      '"state":"OPEN","version":2}}}}';
+    const expected = 'ti2bYNj+FEJ+f3yjR4wIWQZaNkVBPfOCNkZzUuc7SrE=';
+
+    // The env key/url match kaKey/kaUrl, so the app verifies this directly.
+    expect(kaKey).toBe(signatureKey);
+    expect(kaUrl).toBe(notificationUrl);
+    await expect(verifySquareSignature(kaBody, expected)).resolves.toBe(true);
+  });
 });
 
 describe('POST /webhooks/square', () => {

--- a/skills/square-webhooks/examples/fastapi/test_webhook.py
+++ b/skills/square-webhooks/examples/fastapi/test_webhook.py
@@ -61,6 +61,28 @@ class TestVerifySquareSignature:
             is False
         )
 
+    def test_known_answer_signature(self):
+        # Known-answer test: locks the signing construction — HMAC-SHA256 over
+        # (notification_url + raw_body), base64, key used verbatim. The digest is
+        # self-computed (not a Square-produced signature; the order and encoding
+        # were confirmed against a live delivery and the official SDK, 2026-08).
+        # Guards against a regression that flips the order to (body + url) or
+        # base64-decodes the key.
+        ka_body = (
+            '{"merchant_id":"6SSW7HV8K2ST5","type":"order.updated",'
+            '"event_id":"11111111-2222-3333-4444-555555555555",'
+            '"created_at":"2026-08-04T12:00:00.000Z","data":{"type":"order_updated",'
+            '"id":"ORDER123","object":{"order_updated":{"order_id":"ORDER123",'
+            '"state":"OPEN","version":2}}}}'
+        )
+        expected = "ti2bYNj+FEJ+f3yjR4wIWQZaNkVBPfOCNkZzUuc7SrE="
+        assert (
+            verify_square_signature(
+                ka_body.encode(), expected, SIGNATURE_KEY, NOTIFICATION_URL
+            )
+            is True
+        )
+
 
 class TestSquareWebhook:
     """Tests for the Square webhook endpoint."""

--- a/skills/square-webhooks/examples/nextjs/test/webhook.test.ts
+++ b/skills/square-webhooks/examples/nextjs/test/webhook.test.ts
@@ -76,6 +76,24 @@ describe('POST /webhooks/square', () => {
     expect(await res.json()).toEqual({ received: true });
   });
 
+  // Known-answer test: locks the signing construction — HMAC-SHA256 over
+  // (notificationUrl + rawBody), base64, key verbatim. Digest is self-computed
+  // (not Square-produced; order/encoding confirmed against a live delivery and
+  // the official SDK, 2026-08). Guards against a regression that flips the order
+  // to (body + url) or decodes the key.
+  it('accepts a fixed known-answer signature (URL + body, base64)', async () => {
+    const kaBody =
+      '{"merchant_id":"6SSW7HV8K2ST5","type":"order.updated",' +
+      '"event_id":"11111111-2222-3333-4444-555555555555",' +
+      '"created_at":"2026-08-04T12:00:00.000Z","data":{"type":"order_updated",' +
+      '"id":"ORDER123","object":{"order_updated":{"order_id":"ORDER123",' +
+      '"state":"OPEN","version":2}}}}';
+    const expected = 'ti2bYNj+FEJ+f3yjR4wIWQZaNkVBPfOCNkZzUuc7SrE=';
+
+    const res = await POST(makeRequest(kaBody, expected));
+    expect(res.status).toBe(200);
+  });
+
   it('handles the common Square event types', async () => {
     const types = [
       'payment.created',

--- a/skills/square-webhooks/references/overview.md
+++ b/skills/square-webhooks/references/overview.md
@@ -61,14 +61,39 @@ All Square event notifications share the same top-level envelope:
 
 Key fields:
 
-- **`type`** — the event type; dispatch your handler logic on this value.
+- **`type`** — the event type; dispatch your handler logic on this value. Uses
+  **dot** notation (e.g. `order.updated`, `payment.updated`).
 - **`event_id`** — a unique ID for the event; use it for idempotency to skip
   duplicate deliveries (Square may deliver the same event more than once).
 - **`merchant_id`** — the Square account (merchant) the event belongs to.
 - **`created_at`** — ISO 8601 timestamp of when the event occurred.
-- **`data.type`** — the affected object type (e.g. `payment`, `refund`, `order`).
+- **`data.type`** — the affected object type. **Do not conflate this with the
+  top-level `type`.** The nested `data.type` uses **underscore** form and does
+  not always match the dotted event type — e.g. a live `order.updated` event
+  (top-level, dotted) carries `data.type: "order_updated"` (nested,
+  underscored). Dispatch on the top-level `type`, not `data.type`.
 - **`data.id`** — the ID of the affected object.
 - **`data.object`** — the affected object's current state.
+
+> **Confirmed live (2026-08).** An `order.updated` sandbox delivery carried the
+> envelope above with `merchant_id`, top-level `type: "order.updated"`,
+> `event_id`, `created_at`, and `data { type: "order_updated", id, object }`.
+
+## Request Headers
+
+A Square webhook delivery carries these headers (observed live, 2026-08):
+
+| Header | Purpose |
+|--------|---------|
+| `x-square-hmacsha256-signature` | HMAC-SHA256 (base64) signature — **verify this one** |
+| `x-square-signature` | Legacy HMAC-SHA1 (base64) signature — still sent, deprecated |
+| `square-environment` | `Sandbox` or `Production` |
+| `square-subscription-id` | The webhook subscription that produced the delivery |
+| `square-version` | The API version pinned on the subscription (e.g. `2026-07-15`) |
+| `user-agent` | `Square Connect v2` |
+
+Retried deliveries additionally include `square-retry-number` and
+`square-retry-reason` (see below).
 
 ## Full Event Reference
 

--- a/skills/square-webhooks/references/verification.md
+++ b/skills/square-webhooks/references/verification.md
@@ -10,12 +10,13 @@ tampered with in transit) before you act on payment or refund data.
 
 Square signs every webhook with an **HMAC-SHA256**:
 
-- **Header:** `x-square-hmacsha256-signature`
+- **Header:** `x-square-hmacsha256-signature` (44-character base64 digest)
 - **Algorithm:** HMAC-SHA256
 - **Encoding:** base64
 - **Signed content:** the **notification URL** concatenated with the **raw
   request body** — `notificationUrl + rawBody` — in that order
-- **Key:** the **signature key** from your webhook subscription
+- **Key:** the **signature key** from your webhook subscription, used
+  **verbatim** as the HMAC key (do **not** base64-decode it first)
 
 To verify, recompute the HMAC over `notificationUrl + rawBody` using your
 subscription's signature key, base64-encode it, and compare it against the
@@ -24,6 +25,21 @@ header value using a constant-time (timing-safe) comparison.
 > The notification URL is part of the signed content. It must be the **exact**
 > URL registered on the subscription (scheme, host, and path), or the computed
 > signature will not match.
+
+> **Verified against a live sandbox delivery (2026-08).** The `notificationUrl
+> + rawBody` ordering was confirmed empirically — `rawBody + notificationUrl`
+> and body-only both fail to match. The byte-for-byte URL requirement was also
+> confirmed: adding a trailing slash or switching `https`→`http` breaks
+> verification. The signature key is used verbatim as the HMAC key (matching
+> the SDK); base64-decoding it first does not match.
+
+### The legacy `x-square-signature` (SHA-1) header
+
+Square **still delivers** a second, deprecated header alongside the SHA-256 one:
+`x-square-signature`, an HMAC-**SHA1** (base64) over the same `notificationUrl +
+rawBody` content. Confirmed present on `square-version: 2026-07-15`. Do not rely
+on it — **verify the SHA-256 `x-square-hmacsha256-signature` header** — but do
+not be surprised to see it on incoming requests.
 
 ## Implementation
 
@@ -94,13 +110,21 @@ function isValidSquareSignature(rawBody, signature, key, url) {
 
 ## Common Gotchas
 
+- **Use the subscription's Signature Key — NOT an access token.** This is the
+  most common setup mistake. The HMAC key is the **Signature Key** shown on the
+  webhook subscription (short, e.g. `qfjakbt2uWB8DKAMECF-EA`). An OAuth/access
+  token (`EAAA…`) produces no match. If verification never passes, check you are
+  using the Signature Key, not the access token.
 - **Use the raw body.** Verify the exact bytes Square sent. If you parse JSON
   and re-serialize, whitespace and key ordering change and the signature will
   not match. In Express use `express.raw()`; in Next.js use `await request.text()`;
   in FastAPI use `await request.body()`.
-- **The notification URL is part of the signature.** It must match the
-  subscription's registered URL exactly — including `https://`, host, and path.
-  A trailing slash or `http` vs `https` mismatch breaks verification.
+- **The notification URL is part of the signature — byte-for-byte.** It must
+  match the subscription's registered URL exactly — including `https://`, host,
+  and path. A trailing slash or `http` vs `https` mismatch breaks verification
+  (confirmed by testing 2026-08).
+- **Do not base64-decode the Signature Key.** It is used verbatim (as UTF-8) as
+  the HMAC key. Decoding it first yields a different, non-matching digest.
 - **Each subscription has its own signature key.** Sandbox and Production keys
   differ. Verify with the key that matches the environment sending the event.
 - **Use a timing-safe comparison.** Compare with `crypto.timingSafeEqual`


### PR DESCRIPTION
## Summary

Applies firsthand verification findings from a live Square **sandbox** delivery (`order.updated` → Hookdeck source) to the existing `square-webhooks` skill. Independently corroborated against the official `square` SDK (`WebhooksHelper.verifySignature`), which constructs `notificationUrl + requestBody`, HMAC-SHA256, base64.

No change to the core scheme — it was already correct. This upgrades previously-hedged/undocumented bits to **confirmed**, adds the top real-world pitfalls, and pins the construction with known-answer tests.

## Confirmed (were assumed/undocumented, now verified)

- **Signed content = `notificationUrl + rawBody`**, in that order. `body + url` and body-only do **not** match.
- **Notification URL must match byte-for-byte** — a trailing slash or `http`↔`https` swap breaks verification.
- **Signature Key used verbatim** as the HMAC key (do **not** base64-decode).
- **`x-square-signature` (legacy HMAC-SHA1, base64) is still delivered** alongside the SHA-256 header on `square-version: 2026-07-15`. Verify the SHA-256 one; don't be surprised by the SHA-1 one.
- **Envelope (live):** `merchant_id`, dotted top-level `type` (`order.updated`), `event_id`, `created_at`, `data{ type, id, object }`. Nested `data.type` is the **underscore** form (`order_updated`) — flagged to avoid conflating it with the dotted top-level `type`.
- **Observed headers:** `x-square-hmacsha256-signature`, `x-square-signature`, `square-environment`, `square-subscription-id`, `square-version`, `user-agent: Square Connect v2`.

## New gotchas

- **Top setup pitfall:** the HMAC key is the subscription's **Signature Key** (short, e.g. `qfjakbt2uWB8DKAMECF-EA`), **not** an OAuth access token (`EAAA…`) — the access token never matches.
- Do **not** base64-decode the Signature Key.

## Tests

Added a self-consistency **known-answer test** to all three suites (Express/Next.js/FastAPI) locking the URL+body / base64 / verbatim-key construction. The digest is self-computed (not a Square-produced signature — the sandbox key was rotated); the ordering and encoding are corroborated by the live delivery and the SDK.

- Express: 10 passed
- Next.js: 6 passed
- FastAPI: 10 passed
- `validate-provider.sh square-webhooks`: passed

Left as a **draft** pending owner sign-off.