### PR TITLE
fix(woocommerce): deprecate order.restored and product.restored events

### DIFF
--- a/skills/woocommerce-webhooks/references/overview.md
+++ b/skills/woocommerce-webhooks/references/overview.md
@@ -19,11 +19,11 @@ This enables real-time integration between your WooCommerce store and external s
 | `order.created` | New order is placed | Send order confirmation emails, create shipping labels, update inventory |
 | `order.updated` | Order status or details change | Track order fulfillment, send status updates to customers |
 | `order.deleted` | Order is permanently deleted | Clean up external records, reverse inventory changes |
-| `order.restored` | Deleted order is restored | Restore external records, reapply inventory changes |
+| `order.restored` ⚠️ _deprecated 2026-08_ | Deleted order is restored | No longer documented in WooCommerce webhook topics; retained for historical reference |
 | `product.created` | New product is added | Sync to external catalogs, trigger marketing campaigns |
 | `product.updated` | Product details change | Update pricing feeds, sync inventory levels |
 | `product.deleted` | Product is permanently deleted | Remove from external catalogs, update recommendations |
-| `product.restored` | Deleted product is restored | Restore to external catalogs |
+| `product.restored` ⚠️ _deprecated 2026-08_ | Deleted product is restored | No longer documented in WooCommerce webhook topics; retained for historical reference |
 | `customer.created` | New customer account registered | Send welcome emails, add to CRM, create loyalty profiles |
 | `customer.updated` | Customer profile changes | Update CRM records, sync preferences |
 | `customer.deleted` | Customer account deleted | Clean up external profiles, handle GDPR deletion |

--- a/skills/woocommerce-webhooks/references/setup.md
+++ b/skills/woocommerce-webhooks/references/setup.md
@@ -30,11 +30,11 @@ The webhook secret is used to generate signatures for verifying webhook authenti
    - **Order created** - `order.created`
    - **Order updated** - `order.updated`
    - **Order deleted** - `order.deleted`
-   - **Order restored** - `order.restored`
+   - **Order restored** - `order.restored` _(deprecated 2026-08 — no longer documented by WooCommerce)_
    - **Product created** - `product.created`
    - **Product updated** - `product.updated`
    - **Product deleted** - `product.deleted`
-   - **Product restored** - `product.restored`
+   - **Product restored** - `product.restored` _(deprecated 2026-08 — no longer documented by WooCommerce)_
    - **Customer created** - `customer.created`
    - **Customer updated** - `customer.updated`
    - **Customer deleted** - `customer.deleted`


### PR DESCRIPTION
## Change class: events-removed (deprecated-in-place, not deleted)

`order.restored` and `product.restored` are no longer documented anywhere in WooCommerce's webhook docs. Marked deprecated with a date (2026-08) in the skill's event lists rather than deleted, per the "never delete an event type" rule.

## Verification (verify-before-you-fix)

Re-confirmed against the vendor's primary source before editing — the WooCommerce REST API v3 webhooks reference lists only `created`/`updated`/`deleted` for orders and products, with **no** restore variants:
- https://raw.githubusercontent.com/woocommerce/woocommerce-rest-api-docs/trunk/source/includes/wp-api-v3/_webhooks.md

Originating monitor evidence:
- Freshness run 2026-08-04, flag `woocommerce-event_count-20260729` (open since 2026-07-29, hot tier, 5 consecutive changed L1 outcomes)
- L1 `widen()` search across all 9 `docs.urls` pages found no restore variants
- Independent blind re-extraction against the REST API reference (12 topics, no restore variants) and woocommerce.com/document/webhooks/ (category guidance only)
- Registry fix: https://github.com/hookdeck/webhook-registry/pull/1

## Scope

Event lists only, per the events-removed change class:
- `skills/woocommerce-webhooks/references/overview.md` — Common Event Types table
- `skills/woocommerce-webhooks/references/setup.md` — Topic Options list

Verification scheme, examples, and tests are untouched.
