### PR TITLE
fix: correct greendot-webhooks stale x-gd-signature brief, add API-Key header

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -1165,13 +1165,18 @@ providers:
       to the partner-hosted endpoint. The PRIMARY model is OAuth 2.0 client_credentials — Green Dot
       sends Authorization: Bearer <token> with scope "post:webhook" on every delivery; the partner
       validates that token (JWKS/RS256 or introspection in production). Per-partner variants: OAuth,
-      FormOAuth, PartnerOAuth, FormUrlEncodedOAuth, and Certificate (mTLS/PKCS#7). Payloads MAY also
-      carry an OPTIONAL x-gd-signature header validated with a program-specific signing key, but the
-      algorithm/encoding/canonical-payload are NOT documented publicly (obtain from your Green Dot
-      rep) and sample payloads show no signature header — treat it as optional/program-gated. The
-      examples validate an HS256 shared-secret token (self-contained/testable) plus an optional
-      HMAC-SHA256 hex x-gd-signature over the raw body. Endpoints are registered BY your Green Dot
-      rep (no self-serve portal), configured per eventType. Gotchas: the partner MUST echo back the
+      FormOAuth, PartnerOAuth, FormUrlEncodedOAuth, and Certificate (mTLS/PKCS#7). Green Dot also
+      sends an API-Key header (your program's own, static API key) on every delivery per the
+      Outbound HTTP Headers table — it is not a computed signature, just the same key you already
+      hold, so treat a compare against it as at most a weak defense-in-depth check layered on the
+      Bearer token, never a replacement (re-verified against live docs 2026-08-12). Payloads MAY
+      also carry an OPTIONAL x-gd-signature header validated with a program-specific signing key,
+      but the algorithm/encoding/canonical-payload are NOT documented publicly (obtain from your
+      Green Dot rep) — treat it as optional/program-gated. The examples validate an HS256
+      shared-secret Bearer token (self-contained/testable) and deliberately do NOT implement
+      x-gd-signature verification, since there is no published scheme to reproduce — a guessed
+      HMAC would give false confidence in an unverified payload. Endpoints are registered BY your
+      Green Dot rep (no self-serve portal), configured per eventType. Gotchas: the partner MUST echo back the
       x-GD-RequestId header AND respond 200/201 with a JSON responseDetails body
       ({"responseDetails":[{"code":0,"subCode":0,"description":"<x-GD-RequestId>"}]}) or the delivery
       is treated as failed. Retries run on 5xx/timeouts/DNS/connection/SSL failures (and resolved
@@ -1186,12 +1191,13 @@ providers:
       prompt: >
         Create a {framework} webhook handler for Green Dot Embedded Finance (BaaS). Authenticate the
         delivery by validating the incoming OAuth client_credentials Bearer token and requiring the
-        post:webhook scope (return 401 otherwise), then verify the OPTIONAL x-gd-signature header
-        (HMAC-SHA256 hex over the raw body) with a timing-safe comparison only when a program signing
-        key is configured. Parse JSON only after auth passes, dispatch on the eventType field for
-        events like transaction and achTransfer, and acknowledge by echoing the x-GD-RequestId header
-        and returning HTTP 200 with a responseDetails JSON body. If you use any skills to help with
-        this, add a comment noting which skill(s) you referenced.
+        post:webhook scope (return 401 otherwise). Do NOT attempt to verify the x-gd-signature header
+        — Green Dot's public docs do not publish its algorithm, encoding, or canonical payload, so a
+        guessed HMAC would give false confidence; note this in a comment instead. Parse JSON only
+        after auth passes, dispatch on the eventType field for events like transaction and
+        achTransfer, and acknowledge by echoing the x-GD-RequestId header and returning HTTP 200 with
+        a responseDetails JSON body. If you use any skills to help with this, add a comment noting
+        which skill(s) you referenced.
 
   - name: praxis
     displayName: Praxis

--- a/skills/greendot-webhooks/SKILL.md
+++ b/skills/greendot-webhooks/SKILL.md
@@ -65,6 +65,10 @@ proxy — there is no application-level token to check.
 > (and signing key) from your Green Dot representative before implementing any
 > check. Authenticity comes from the OAuth Bearer token (and/or mTLS). See
 > [TODO.md](TODO.md).
+>
+> Green Dot also sends an `API-Key` header (your program's own static key,
+> echoed back) on every delivery — it is not a signature, so don't treat it as
+> proof of authenticity beyond weak defense-in-depth on top of the Bearer token.
 
 Then **echo the `x-GD-RequestId` header** back and respond `200`/`201` with a
 `responseDetails` body, otherwise Green Dot treats the delivery as failed:

--- a/skills/greendot-webhooks/references/overview.md
+++ b/skills/greendot-webhooks/references/overview.md
@@ -26,11 +26,15 @@ by your rep:
 - **Certificate** — mutual TLS (mTLS) / PKCS#7 client certificates
 
 A delivery may also carry an **`x-gd-signature`** header, but its algorithm,
-encoding, and canonical payload are **not documented publicly**, and sample
-payloads show no signature header. This skill therefore does **not** verify it —
-a guessed HMAC would give false confidence. If you need payload-level
-verification, obtain the specification (and signing key) from your Green Dot
-representative first.
+encoding, and canonical payload are **not documented publicly**. This skill
+therefore does **not** verify it — a guessed HMAC would give false confidence.
+If you need payload-level verification, obtain the specification (and signing
+key) from your Green Dot representative first.
+
+Green Dot also sends an **`API-Key`** header on every delivery — your
+program's own, static API key. It is not a computed signature (just the same
+key you already hold), so at most treat a compare against it as weak
+defense-in-depth layered on the Bearer token check, never as a replacement.
 
 See [verification.md](verification.md) for details.
 
@@ -41,6 +45,7 @@ See [verification.md](verification.md) for details.
 | `Authorization: Bearer <token>` | OAuth client_credentials token, scope `post:webhook` |
 | `x-GD-RequestId` | Correlation id — **you must echo this back** in your response |
 | `x-gd-signature` | May be present; algorithm undocumented — not verified by this skill |
+| `API-Key` | Your program's own static API key, echoed back — not a computed signature |
 | `User-Agent: greendot-baas/3.0.0` | Identifies Green Dot's delivery agent |
 | `Content-Type: application/json` | JSON body |
 

--- a/skills/greendot-webhooks/references/verification.md
+++ b/skills/greendot-webhooks/references/verification.md
@@ -90,6 +90,15 @@ Until you have that specification, rely on the OAuth Bearer token (and/or the
 Certificate/mTLS transport) for authenticity — that is Green Dot's documented
 inbound-auth model.
 
+## 2b. The `API-Key` header is informational, not a signature
+
+Green Dot's docs also list an `API-Key` header sent on every delivery, carrying
+**your program's own, static API key**. Do not mistake this for a signature: it
+is not computed from the payload and does not rotate per request — it is the
+same value you already hold. If you choose to compare it, treat it as weak
+defense-in-depth layered on top of the OAuth Bearer token check (§1), never as
+a replacement for it.
+
 ## 3. Acknowledge Correctly
 
 After the token check passes and you have handled the event, respond `200`/`201`
@@ -108,6 +117,8 @@ and:
   token (or the Certificate/mTLS transport), not from a payload signature.
 - **Do not invent an `x-gd-signature` HMAC.** Its algorithm is undocumented; a
   guessed check gives false confidence. Get the spec from your rep first.
+- **Don't treat `API-Key` as a signature.** It's your program's own static key,
+  echoed back unchanged — not proof the payload wasn't tampered with.
 - **Always echo `x-GD-RequestId`.** Omitting it (or the `responseDetails` body)
   makes Green Dot treat the delivery as failed and retry it.
 - **Timing-safe compare**, and guard against unequal lengths (Node's


### PR DESCRIPTION
## Why

Triggered by webhook-registry-checks flag `greendot-verification-20260812`
(evidence bundle: `state/flags/greendot-verification-20260812.md` in
`hookdeck/webhook-registry-checks`, class `verification-changed`). The flag's
blind re-extraction found every recorded signature/HMAC/header term absent
from the live `webhooks-overview` page, and recommended the skill author
re-verify the full model.

## What I found

Re-fetched `https://developer.greendot.com/embedded-finance/docs/webhooks-overview`
live today (200, 30,386 bytes — same size the flag recorded) and the
verification/testing reference page linked from `providers.yaml`
(`.../reference/event_post_testeventwebhook_rcv`).

**The skill's actual shipped content (`references/verification.md`,
`references/overview.md`, `SKILL.md`, `TODO.md`, and all three
`examples/*`) was already correct** and needed no model change: OAuth 2.0
client_credentials Bearer token is the documented, primary inbound-auth
model; `x-gd-signature` is mentioned but its algorithm/encoding/canonical
payload remain undocumented, so it's deliberately not verified anywhere in
the shipped code. No signature/HMAC scheme is published on the live page
today — consistent with what the skill has said since it was authored
(PR #164).

**Two things genuinely needed fixing**, both scoped to the verification
section:

1. **`providers.yaml`'s `notes` and `testScenario.prompt` were stale** —
   they still described the examples as implementing an "optional
   HMAC-SHA256 hex `x-gd-signature`" check. That contradicts the real
   shipped code (which explicitly does *not* verify `x-gd-signature`, per
   `TODO.md`) and would propagate the wrong fact on any future
   regeneration. Corrected the brief to match reality.
2. **A newly-confirmed fact wasn't captured anywhere**: the live docs'
   Outbound HTTP Headers table now lists an `API-Key` header sent on every
   delivery (the partner's own static API key, echoed back). Added it to
   `overview.md` / `verification.md` / `SKILL.md`, explicitly hedged as
   informational only — not a computed signature, and not a replacement for
   the Bearer token check.

Also dropped an unconfirmable claim ("sample payloads show no signature
header") from `overview.md` — not verifiable from the current
`webhooks-overview` page, which contains no payload samples.

**Out of scope, untouched:** event list, payload shape, example
implementation code (all already correct and unchanged).

## Testing

- `./scripts/validate-provider.sh greendot-webhooks` — PASSED
- `examples/express`: `npm test` — 6/6 passed
- `examples/nextjs`: `npm test` — 6/6 passed
- `examples/fastapi`: fresh scratch venv + `pytest` — 6/6 passed

No live-verification account was available for this update, so this stops
at the reviewed draft PR per the update-task contract.
