### PR TITLE
fix: document statsig url_verification handshake and answer it in examples

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -2613,7 +2613,11 @@ providers:
       "created", "updated"). Setup: Project Settings > Integrations > Generic Webhook,
       enter destination URL, use Event Filtering to pick Exposures vs Config Changes.
       No official webhook-verification SDK; docs give HMAC pseudo-code. Retry behavior
-      not documented.
+      not documented. REQUIRED HANDSHAKE: on save, Statsig POSTs
+      {"data":{"event":"url_verification","verification_code":"..."}} and the endpoint
+      must reply 200 with {"verification_code":"<same value>"} or the webhook silently
+      never registers (no events, no log entries). Answer the handshake before
+      enforcing signature verification — it only echoes a caller-supplied value.
     testScenario:
       events:
         - config_change

--- a/skills/statsig-webhooks/SKILL.md
+++ b/skills/statsig-webhooks/SKILL.md
@@ -22,6 +22,8 @@ metadata:
   experiment, or dynamic config `created` / `updated` events)
 - Handling Statsig's JSON **batch** payloads (arrays) and the config-change
   `{ "data": [...] }` envelope
+- Answering the **`url_verification` handshake** so the webhook actually
+  registers (a missed handshake fails silently — no events, no log entries)
 
 ## Essential Code (USE THIS)
 
@@ -33,6 +35,28 @@ before verifying will change byte ordering and break the signature.
 
 > **Note:** Statsig's `X-Statsig-Request-Timestamp` is a Unix timestamp in
 > **milliseconds** (13 digits), not seconds.
+
+### URL Validation Handshake (answer this or the webhook never registers)
+
+When you save the Generic Webhook integration, Statsig POSTs a validation
+request to the destination URL and registers the webhook only if the endpoint
+echoes the code back:
+
+```json
+{ "data": { "event": "url_verification", "verification_code": "abc123" } }
+```
+
+Respond `200` with a JSON body carrying the **same value**:
+
+```json
+{ "verification_code": "abc123" }
+```
+
+A missed handshake fails **silently**: the webhook never registers, no event is
+ever delivered, and nothing appears in any delivery log. Answer it before
+enforcing signature verification — it only echoes a value the caller supplied,
+the same way an unauthenticated URL-check ping is answered for providers like
+Mailchimp. The Express handler below includes the responder.
 
 ### Statsig Signature Verification (JavaScript)
 
@@ -81,12 +105,17 @@ app.post('/webhooks/statsig',
     const signature = req.headers['x-statsig-signature'];
     const timestamp = req.headers['x-statsig-request-timestamp'];
     const rawBody = req.body.toString('utf8');
+    const payload = JSON.parse(rawBody);
+
+    // URL validation handshake (sent when the integration is saved):
+    // echo the code back or the webhook never registers.
+    if (payload?.data?.event === 'url_verification') {
+      return res.status(200).json({ verification_code: payload.data.verification_code });
+    }
 
     if (!verifyStatsigRequest(rawBody, signature, timestamp, process.env.STATSIG_WEBHOOK_SECRET)) {
       return res.status(401).send('Invalid signature');
     }
-
-    const payload = JSON.parse(rawBody);
 
     // Statsig delivers batches. Config changes arrive as { data: [...] };
     // exposure events arrive as a top-level JSON array.

--- a/skills/statsig-webhooks/examples/express/src/index.js
+++ b/skills/statsig-webhooks/examples/express/src/index.js
@@ -63,16 +63,23 @@ app.post('/webhooks/statsig',
     const timestamp = req.headers['x-statsig-request-timestamp'];
     const rawBody = req.body.toString('utf8');
 
-    if (!verifyStatsigRequest(rawBody, signature, timestamp, process.env.STATSIG_WEBHOOK_SECRET)) {
-      console.error('Statsig signature verification failed');
-      return res.status(401).send('Invalid signature');
-    }
-
     let payload;
     try {
       payload = JSON.parse(rawBody);
     } catch {
       return res.status(400).send('Invalid JSON');
+    }
+
+    // URL validation handshake (sent when the integration is saved): echo the
+    // code back or the webhook never registers. It only reflects a
+    // caller-supplied value, so it is answered before signature verification.
+    if (payload?.data?.event === 'url_verification') {
+      return res.status(200).json({ verification_code: payload.data.verification_code });
+    }
+
+    if (!verifyStatsigRequest(rawBody, signature, timestamp, process.env.STATSIG_WEBHOOK_SECRET)) {
+      console.error('Statsig signature verification failed');
+      return res.status(401).send('Invalid signature');
     }
 
     // Statsig delivers batches. Config changes arrive as { data: [...] };

--- a/skills/statsig-webhooks/examples/express/test/webhook.test.js
+++ b/skills/statsig-webhooks/examples/express/test/webhook.test.js
@@ -110,6 +110,20 @@ describe('POST /webhooks/statsig', () => {
     expect(res.status).toBe(401);
   });
 
+  it('answers the url_verification handshake without a signature', async () => {
+    const body = JSON.stringify({
+      data: { event: 'url_verification', verification_code: 'test_code_123' },
+    });
+
+    const res = await request(app)
+      .post('/webhooks/statsig')
+      .set('Content-Type', 'application/json')
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ verification_code: 'test_code_123' });
+  });
+
   it('returns 200 for a valid config-change batch', async () => {
     const body = JSON.stringify({
       data: [

--- a/skills/statsig-webhooks/examples/fastapi/main.py
+++ b/skills/statsig-webhooks/examples/fastapi/main.py
@@ -61,13 +61,21 @@ async def statsig_webhook(request: Request):
     timestamp_header = request.headers.get("x-statsig-request-timestamp")
     signing_secret = os.environ.get("STATSIG_WEBHOOK_SECRET")
 
-    if not verify_statsig_request(raw_body, signature_header, timestamp_header, signing_secret):
-        return PlainTextResponse("Invalid signature", status_code=401)
-
     try:
         payload = json.loads(raw_body)
     except json.JSONDecodeError:
         return PlainTextResponse("Invalid JSON", status_code=400)
+
+    # URL validation handshake (sent when the integration is saved): echo the
+    # code back or the webhook never registers. It only reflects a
+    # caller-supplied value, so it is answered before signature verification.
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        if isinstance(data, dict) and data.get("event") == "url_verification":
+            return JSONResponse({"verification_code": data.get("verification_code")})
+
+    if not verify_statsig_request(raw_body, signature_header, timestamp_header, signing_secret):
+        return PlainTextResponse("Invalid signature", status_code=401)
 
     # Statsig delivers batches. Config changes arrive as {"data": [...]};
     # exposure events arrive as a top-level JSON array.

--- a/skills/statsig-webhooks/examples/fastapi/test_webhook.py
+++ b/skills/statsig-webhooks/examples/fastapi/test_webhook.py
@@ -169,6 +169,17 @@ class TestStatsigWebhookEndpoint:
         )
         assert response.status_code == 200
 
+    def test_url_verification_handshake_answered_without_signature(self):
+        body = b'{"data": {"event": "url_verification", "verification_code": "test_code_123"}}'
+
+        response = client.post(
+            "/webhooks/statsig",
+            content=body,
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"verification_code": "test_code_123"}
+
     def test_invalid_json_returns_400(self):
         body = b"not valid json"
         ts = current_timestamp()

--- a/skills/statsig-webhooks/examples/nextjs/app/webhooks/statsig/route.ts
+++ b/skills/statsig-webhooks/examples/nextjs/app/webhooks/statsig/route.ts
@@ -58,16 +58,23 @@ export async function POST(request: NextRequest) {
   const signature = request.headers.get('x-statsig-signature');
   const timestamp = request.headers.get('x-statsig-request-timestamp');
 
-  if (!verifyStatsigRequest(rawBody, signature, timestamp, process.env.STATSIG_WEBHOOK_SECRET!)) {
-    console.error('Statsig signature verification failed');
-    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
-  }
-
   let payload: any;
   try {
     payload = JSON.parse(rawBody);
   } catch {
     return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  // URL validation handshake (sent when the integration is saved): echo the
+  // code back or the webhook never registers. It only reflects a
+  // caller-supplied value, so it is answered before signature verification.
+  if (payload?.data?.event === 'url_verification') {
+    return NextResponse.json({ verification_code: payload.data.verification_code });
+  }
+
+  if (!verifyStatsigRequest(rawBody, signature, timestamp, process.env.STATSIG_WEBHOOK_SECRET!)) {
+    console.error('Statsig signature verification failed');
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
   }
 
   // Statsig delivers batches. Config changes arrive as { data: [...] };

--- a/skills/statsig-webhooks/references/setup.md
+++ b/skills/statsig-webhooks/references/setup.md
@@ -15,6 +15,12 @@
 1. In the Generic Webhook integration card, enter your public endpoint in the
    **destination URL** field, e.g. `https://your-domain.com/webhooks/statsig`.
 2. Save the integration.
+3. On save, Statsig POSTs a **URL validation request** to the endpoint:
+   `{ "data": { "event": "url_verification", "verification_code": "..." } }`.
+   Your endpoint must already be running and reply `200` with
+   `{ "verification_code": "<the same value>" }`, or the webhook silently never
+   registers — see
+   [verification.md](verification.md#url-validation-handshake).
 
 ## 3. Choose What to Receive (Event Filtering)
 

--- a/skills/statsig-webhooks/references/verification.md
+++ b/skills/statsig-webhooks/references/verification.md
@@ -110,6 +110,26 @@ def verify_statsig_request(raw_body: bytes, signature_header: str, timestamp_hea
     return hmac.compare_digest(expected, signature_header)
 ```
 
+## URL Validation Handshake
+
+Before any signed delivery arrives, Statsig validates the endpoint. When the
+Generic Webhook integration is saved, Statsig POSTs:
+
+```json
+{ "data": { "event": "url_verification", "verification_code": "abc123" } }
+```
+
+The endpoint must respond `200` with a JSON body echoing the same value:
+
+```json
+{ "verification_code": "abc123" }
+```
+
+If the handshake is not answered, the webhook silently never registers: no
+events are delivered and nothing appears in any delivery log. Answer it before
+enforcing signature verification — the responder only echoes a value the caller
+supplied, so it is safe to serve unauthenticated.
+
 ## Common Gotchas
 
 - **Use the raw body.** If you let Express or FastAPI parse JSON first and then
@@ -138,3 +158,4 @@ def verify_statsig_request(raw_body: bytes, signature_header: str, timestamp_hea
 | Off-by-one mismatch | Forgot the `v0=` prefix on the computed signature. |
 | Tests fail with "Cannot read property of undefined" | Header lookup is case-sensitive in your framework. Statsig sends lowercase over HTTP/2. |
 | Works in dev, fails in production | Production uses a different signing secret. Each integration has its own. |
+| No requests ever arrive, nothing in any log | The `url_verification` handshake was not answered when the integration was saved, so the webhook never registered. Add the responder and re-save. |


### PR DESCRIPTION
## What

Statsig POSTs `{"data":{"event":"url_verification","verification_code":"..."}}` to the destination URL when the Generic Webhook integration is saved, and only registers the webhook if the endpoint replies `200` with `{"verification_code":"<same value>"}`. The statsig-webhooks skill never mentioned this handshake (zero occurrences of `verification_code`), so a receiver built from it silently never registered: no events delivered, nothing in any delivery log, no error to diagnose.

Evidence: `hookdeck/http-ingestion` `cloudflare/src/common/platforms/statsig.ts`, which answers this handshake at ingestion.

## Changes

- **SKILL.md**: new "URL Validation Handshake" section (modeled on how the mailchimp skill documents its GET URL check), a When-to-Use bullet, and the handshake responder added to the Express handler snippet
- **references/verification.md**: handshake section, plus a "no requests ever arrive, nothing in any log" row in the debugging table
- **references/setup.md**: validation step added to the save flow
- **providers.yaml**: handshake appended to the statsig notes
- **examples (express / fastapi / nextjs)**: handlers now parse first and answer the handshake before signature verification — it only echoes a caller-supplied value, so it is safe to serve unauthenticated, the same reasoning as mailchimp's unauthenticated GET ping. Endpoint tests added for express and fastapi (the nextjs suite only unit-tests the verify function, so its handler is fixed but no route-level test was added).

## Tests

- express: 15/15 pass (includes new handshake test)
- fastapi: 15 pass (includes new handshake test)
- nextjs: 12/12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)