### PR TITLE
fix(mailersend): stop the brief asserting a pause deadline the docs don't give

### DIFF
--- a/providers.yaml
+++ b/providers.yaml
@@ -1933,8 +1933,10 @@ providers:
       `data.meta` is an empty ARRAY `[]` when empty (not an object), which breaks naive typed
       deserialisation. `data.type` is the bare activity name (`sent`) without the `activity.`
       prefix. Delivery: respond within 3 seconds or the attempt fails; exponential backoff
-      retries for ~3 days then the webhook is auto-paused; 4xx other than 429 and DNS failures
-      are never retried. No delivery-id header, no source-IP allowlist, no X-MailerSend-*
+      retries for ~3 days. SEPARATELY, a webhook whose endpoint "stays down too long" is
+      auto-paused and must be re-enabled from the dashboard — the docs never tie that threshold
+      to the retry window, so do not assert they are the same deadline. 4xx other than 429 and
+      DNS failures are never retried. No delivery-id header, no source-IP allowlist, no X-MailerSend-*
       headers — dedupe on data.id. The official Node SDK ships MailerSendUtils.verifyWebHook
       but it is NOT exported from the package entry point and calls timingSafeEqual without a
       length guard (throws RangeError); the Python SDK has no verification helper — verify


### PR DESCRIPTION
One-line correction to the `mailersend` research brief in `providers.yaml`.

The brief said retries run "~3 days then the webhook is auto-paused". The docs give those as **two separate facts** — exponential backoff for about 3 days, and, in a different section, that a webhook whose endpoint "stays down too long" is automatically paused. Nothing ties the pause threshold to the retry window, so the brief was manufacturing a deadline.

This was already corrected in `SKILL.md` when the skill shipped in #187. Fixing it in the brief too, because the brief is the generator's input and the bad fact would come back on a regeneration.

**Verified and deliberately left alone while here:** the brief's claim that `MailerSendUtils.verifyWebHook` is not reachable from the package entry point is correct — `mailersend@3.2.0`'s `lib/index.js` re-exports only `./modules/MailerSend.module` and `./models`; `services/` is not among them.